### PR TITLE
Add support for raw strings

### DIFF
--- a/corpus/literals.txt
+++ b/corpus/literals.txt
@@ -229,9 +229,13 @@ extension URL {
             (control_transfer_statement
               (raw_string_literal
                 (raw_str_part)
-                (simple_identifier)
+                (raw_str_interpolation
+                    (raw_str_interpolation_start)
+                    (simple_identifier))
                 (raw_str_part)
-                (simple_identifier)
+                (raw_str_interpolation
+                    (raw_str_interpolation_start)
+                    (simple_identifier))
                 (raw_str_end_part)))))))))
 
 ==================
@@ -242,7 +246,7 @@ print(#"Hello \#(world /* commented out)"#)  */ )"#)
 
 let _ = ##"Multiple pound signs \##(interpolated): still one part "# not done yet "##
 let _ = ##"Fake \#(interpolation) and unused # pound signs "##
-let _ = ##"\##(a)\#(b)\##(c)\###(d)\##(e)\##"##
+let _ = ##"\##(a)\#(b)\##(c)\#(d)"# ##"##
 
 ---
 
@@ -254,8 +258,10 @@ let _ = ##"\##(a)\#(b)\##(c)\###(d)\##(e)\##"##
         (value_argument
           (raw_string_literal
             (raw_str_part)
-            (simple_identifier)
-            (multiline_comment)
+            (raw_str_interpolation
+                (raw_str_interpolation_start)
+                (simple_identifier)
+                (multiline_comment))
             (raw_str_end_part))))))
   (property_declaration
     (value_binding_pattern
@@ -263,7 +269,9 @@ let _ = ##"\##(a)\#(b)\##(c)\###(d)\##(e)\##"##
         (wildcard_pattern)))
     (raw_string_literal
       (raw_str_part)
-      (simple_identifier)
+      (raw_str_interpolation
+          (raw_str_interpolation_start)
+          (simple_identifier))
       (raw_str_end_part)))
   (property_declaration
     (value_binding_pattern
@@ -277,9 +285,11 @@ let _ = ##"\##(a)\#(b)\##(c)\###(d)\##(e)\##"##
         (wildcard_pattern)))
     (raw_string_literal
       (raw_str_part)
-      (simple_identifier)
+      (raw_str_interpolation
+          (raw_str_interpolation_start)
+          (simple_identifier))
       (raw_str_part)
-      (simple_identifier)
-      (raw_str_part)
-      (simple_identifier)
+      (raw_str_interpolation
+          (raw_str_interpolation_start)
+          (simple_identifier))
       (raw_str_end_part))))

--- a/grammar.js
+++ b/grammar.js
@@ -98,6 +98,7 @@ module.exports = grammar({
   externals: ($) => [
     $.multiline_comment,
     $.raw_str_part,
+    $.raw_str_continuing_indicator,
     $.raw_str_end_part,
     $._semi,
     $._arrow_operator,
@@ -202,7 +203,21 @@ module.exports = grammar({
       ),
 
     raw_string_literal: ($) =>
-      seq(repeat(seq($.raw_str_part, $._expression)), $.raw_str_end_part),
+      seq(
+        repeat(
+          seq(
+            $.raw_str_part,
+            $.raw_str_interpolation,
+            optional($.raw_str_continuing_indicator)
+          )
+        ),
+        $.raw_str_end_part
+      ),
+
+    raw_str_interpolation: ($) =>
+      seq($.raw_str_interpolation_start, $._expression, ")"),
+
+    raw_str_interpolation_start: ($) => /\\#*\(/,
 
     _multi_line_string_content: ($) =>
       choice($._multi_line_str_text, $._escaped_identifier, '"'),


### PR DESCRIPTION
Uses a custom scanner and ongoing state to parse code like:
```
extension URL {
    func html(withTitle title: String) -> String {
        return #"<a href="\#(absoluteString)">\#(title)</a>"#
    }
}
```

Fixes #7, #11
