### PR TITLE
Fix switch statement default cases

### DIFF
--- a/corpus/statements.txt
+++ b/corpus/statements.txt
@@ -170,6 +170,7 @@ switch something {
     case .pattern: return "Hello"
     case expression: return "and"
     case "Literal": return "Goodbye"
+    default: return ":)"
 }
 
 ---
@@ -184,6 +185,9 @@ switch something {
             (statements (control_transfer_statement (line_string_literal))))
         (switch_entry
             (switch_pattern (line_string_literal))
+            (statements (control_transfer_statement (line_string_literal))))
+        (switch_entry
+            (default_keyword)
             (statements (control_transfer_statement (line_string_literal))))))
 
 ==================
@@ -218,6 +222,7 @@ case .notExecutable(let path?):
             (statements (simple_identifier)))
         (switch_entry
             (modifiers (attribute (user_type (type_identifier))))
+            (default_keyword)
             (statements (control_transfer_statement (line_string_literal)))))
     (switch_expression
         (self_expression)

--- a/grammar.js
+++ b/grammar.js
@@ -110,6 +110,7 @@ module.exports = grammar({
     $._equal_sign,
     $._throws_keyword,
     $._rethrows_keyword,
+    $.default_keyword,
   ],
 
   rules: {
@@ -663,7 +664,7 @@ module.exports = grammar({
         optional($.modifiers),
         choice(
           seq("case", $.switch_pattern, repeat(seq(",", $.switch_pattern))),
-          "default"
+          $.default_keyword
         ),
         optional(seq("where", $._expression)),
         ":",

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -13,10 +13,11 @@ enum TokenType {
     NIL_COALESCING_OPERATOR,
     EQUAL_SIGN,
     THROWS_KEYWORD,
-    RETHROWS_KEYWORD
+    RETHROWS_KEYWORD,
+    DEFAULT_KEYWORD
 };
 
-#define CROSS_SEMI_OPERATOR_COUNT 10
+#define CROSS_SEMI_OPERATOR_COUNT 11
 
 const char* CROSS_SEMI_OPERATORS[CROSS_SEMI_OPERATOR_COUNT] = {
     "->",
@@ -28,7 +29,8 @@ const char* CROSS_SEMI_OPERATORS[CROSS_SEMI_OPERATOR_COUNT] = {
     "??",
     "=",
     "throws",
-    "rethrows"
+    "rethrows",
+    "default"
 };
 
 const int32_t CROSS_SEMI_OP_LENS[CROSS_SEMI_OPERATOR_COUNT] = {
@@ -41,7 +43,8 @@ const int32_t CROSS_SEMI_OP_LENS[CROSS_SEMI_OPERATOR_COUNT] = {
     2,
     1,
     6,
-    8
+    8,
+    7
 };
 
 const enum TokenType CROSS_SEMI_SYMBOLS[CROSS_SEMI_OPERATOR_COUNT] = {
@@ -54,7 +57,8 @@ const enum TokenType CROSS_SEMI_SYMBOLS[CROSS_SEMI_OPERATOR_COUNT] = {
     NIL_COALESCING_OPERATOR,
     EQUAL_SIGN,
     THROWS_KEYWORD,
-    RETHROWS_KEYWORD
+    RETHROWS_KEYWORD,
+    DEFAULT_KEYWORD
 };
 
 void *tree_sitter_swift_external_scanner_create() {


### PR DESCRIPTION
Custom scanner parsing of `_semi` broke how switch statement defaults
are parsed, but the corpus didn't have a basic switch default case. This
restores that by making `default` one of the keywords the scanner
handles.

Fixes #13
