### PR TITLE
Adding support for key-path expressions

### DIFF
--- a/corpus/expressions.txt
+++ b/corpus/expressions.txt
@@ -446,3 +446,92 @@ Image.url(url, isLoaded: $done)
         (value_argument
           (simple_identifier)
           (simple_identifier))))))
+
+===
+Key-path expressions
+===
+
+let pathToProperty = \SomeStructure.someValue
+
+let c = SomeClass(someProperty: 10)
+c.observe(\.someProperty) { object, change in
+    // ...
+}
+
+compoundValue[keyPath: \.self] = (a: 10, b: 20)
+
+let nestedKeyPath = \OuterStructure.outer.someValue
+
+---
+
+(source_file
+  (property_declaration
+    (value_binding_pattern
+      (non_binding_pattern
+        (simple_identifier)))
+    (navigation_expression
+      (key_path_expression
+        (type_identifier))
+      (navigation_suffix
+        (simple_identifier))))
+  (property_declaration
+    (value_binding_pattern
+      (non_binding_pattern
+        (simple_identifier)))
+    (call_expression
+      (simple_identifier)
+      (call_suffix
+        (value_arguments
+          (value_argument
+            (simple_identifier)
+            (integer_literal))))))
+  (call_expression
+    (call_expression
+      (navigation_expression
+        (simple_identifier)
+        (navigation_suffix
+          (simple_identifier)))
+      (call_suffix
+        (value_arguments
+          (value_argument
+            (navigation_expression
+              (key_path_expression)
+              (navigation_suffix
+                (simple_identifier)))))))
+    (call_suffix
+      (lambda_literal
+        (lambda_function_type
+          (lambda_function_type_parameters
+            (simple_identifier)
+            (simple_identifier)))
+        (comment))))
+  (assignment
+    (directly_assignable_expression
+      (call_expression
+        (simple_identifier)
+        (call_suffix
+          (value_arguments
+            (value_argument
+              (simple_identifier)
+              (navigation_expression
+                (key_path_expression)
+                (navigation_suffix
+                  (simple_identifier))))))))
+    (tuple_expression
+      (simple_identifier)
+      (integer_literal)
+      (simple_identifier)
+      (integer_literal)))
+  (property_declaration
+    (value_binding_pattern
+      (non_binding_pattern
+        (simple_identifier)))
+    (navigation_expression
+      (navigation_expression
+        (key_path_expression
+          (type_identifier))
+        (navigation_suffix
+          (simple_identifier)))
+      (navigation_suffix
+        (simple_identifier)))))
+

--- a/grammar.js
+++ b/grammar.js
@@ -542,6 +542,7 @@ module.exports = grammar({
         $.do_expression,
         $.try_expression,
         $._referenceable_operator,
+        $.key_path_expression,
         alias($._three_dot_operator, $.fully_open_range)
       ),
 
@@ -715,6 +716,33 @@ module.exports = grammar({
           $._try_operator,
           choice($._expression, $.assignment)
         )
+      ),
+
+    key_path_expression: ($) =>
+      prec.left(
+        seq(
+          "\\",
+          optional(
+            choice($._simple_user_type, $.array_type, $.dictionary_type)
+          ),
+          repeat(seq(".", $._key_path_component))
+        )
+      ),
+
+    _key_path_component: ($) =>
+      prec.left(
+        choice(
+          seq($.simple_identifier, repeat($._key_path_postfixes)),
+          repeat1($._key_path_postfixes)
+        )
+      ),
+
+    _key_path_postfixes: ($) =>
+      choice(
+        "?",
+        "!",
+        "self",
+        seq("[", optional(sep1($.value_argument, ",")), "]")
       ),
 
     _try_operator: ($) => choice("try", "try!", "try?"),

--- a/script-data/known_failures.txt
+++ b/script-data/known_failures.txt
@@ -3,10 +3,7 @@ Alamofire/Tests/SessionManagerTests.swift
 lottie-ios/lottie-swift/src/Private/Model/Extensions/KeyedDecodingContainerExtensions.swift
 lottie-ios/lottie-swift/src/Private/Utility/Primitives/BezierPath.swift
 lottie-ios/lottie-swift/src/Private/Utility/Primitives/CompoundBezierPath.swift
-vapor/Tests/VaporTests/ApplicationTests.swift
 vapor/Sources/Vapor/Middleware/CORSMiddleware.swift
-vapor/Sources/Vapor/Response/Response.swift
-vapor/Sources/Vapor/Request/Request.swift
 Kingfisher/Sources/SwiftUI/ImageBinder.swift
 shadowsocks/ShadowsocksX-NG/ServerProfile.swift
 Carthage/Source/carthage/Outdated.swift


### PR DESCRIPTION
Fixes #21

This adds rudimentary support, but some edge cases around indexing don't
yet work. I'm checking this in as-is because it can handle the cases
from `top-repos`; someone who needs the more advanced behavior can help
iron out those edge cases.
