### PR TITLE
Allow if/switch/do to be labeled statements

### DIFF
--- a/corpus/statements.txt
+++ b/corpus/statements.txt
@@ -116,7 +116,7 @@ outerLoop: for outerObject in dataArray {
                 (simple_identifier))
             (user_type (type_identifier)))
         (simple_identifier))
-    (loop_label)
+    (statement_label)
     (for_statement
         (simple_identifier)
         (simple_identifier)
@@ -125,7 +125,7 @@ outerLoop: for outerObject in dataArray {
                 (simple_identifier)
                 (simple_identifier)
                 (statements
-                    (if_expression
+                    (if_statement
                         (equality_expression (simple_identifier) (simple_identifier))
                         (statements
                             (assignment
@@ -175,7 +175,7 @@ switch something {
 
 ---
 (source_file
-    (switch_expression
+    (switch_statement
         (simple_identifier)
         (switch_entry
             (switch_pattern (simple_identifier))
@@ -207,7 +207,7 @@ case .notExecutable(let path?):
 
 ---
 (source_file
-    (switch_expression
+    (switch_statement
         (simple_identifier)
         (switch_entry
             (switch_pattern
@@ -224,7 +224,7 @@ case .notExecutable(let path?):
             (modifiers (attribute (user_type (type_identifier))))
             (default_keyword)
             (statements (control_transfer_statement (line_string_literal)))))
-    (switch_expression
+    (switch_statement
         (self_expression)
         (switch_entry
             (switch_pattern
@@ -271,7 +271,7 @@ do {
 
 ---
 (source_file
-    (do_expression
+    (do_statement
         (statements
             (property_declaration
                 (value_binding_pattern (non_binding_pattern (simple_identifier)))
@@ -309,7 +309,7 @@ do {
                 (simple_identifier)
                 (non_binding_pattern (simple_identifier))))
         (catch_block))
-    (do_expression
+    (do_statement
         (statements
             (property_declaration
                 (value_binding_pattern (non_binding_pattern (simple_identifier)))
@@ -329,24 +329,25 @@ if case .someCase(_) = otherThing() {
 if let something: MyType = doThing() {
 }
 
-if a.isEmpty, let b = getB() {
+someLabel: if a.isEmpty, let b = getB() {
 }
 
 ---
 
 (source_file
-    (if_expression
+    (if_statement
         (value_binding_pattern (non_binding_pattern (simple_identifier)))
         (call_expression (simple_identifier) (call_suffix (value_arguments)))
         (statements (call_expression (simple_identifier) (call_suffix (value_arguments)))))
-    (if_expression
+    (if_statement
         (binding_pattern (simple_identifier) (wildcard_pattern))
         (call_expression (simple_identifier) (call_suffix (value_arguments))))
-    (if_expression
+    (if_statement
         (value_binding_pattern (non_binding_pattern (simple_identifier)))
         (type_annotation (user_type (type_identifier)))
         (call_expression (simple_identifier) (call_suffix (value_arguments))))
-    (if_expression
+    (statement_label)
+    (if_statement
         (navigation_expression (simple_identifier) (navigation_suffix (simple_identifier)))
         (value_binding_pattern (non_binding_pattern (simple_identifier)))
         (call_expression (simple_identifier) (call_suffix (value_arguments)))))
@@ -363,7 +364,7 @@ return default
 ---
 
 (source_file
-    (if_expression
+    (if_statement
         (value_binding_pattern (non_binding_pattern (simple_identifier)))
         (call_expression
             (try_expression
@@ -390,14 +391,14 @@ if let something = doThing(), let somethingElse = something.somethingElse() {
 ---
 
 (source_file
-    (if_expression
+    (if_statement
         (value_binding_pattern (non_binding_pattern (simple_identifier)))
         (call_expression (simple_identifier) (call_suffix (value_arguments)))
         (call_expression
             (navigation_expression (simple_identifier) (navigation_suffix (simple_identifier)))
             (call_suffix (value_arguments)))
         (statements (call_expression (simple_identifier) (call_suffix (value_arguments)))))
-    (if_expression
+    (if_statement
         (value_binding_pattern
             (non_binding_pattern (simple_identifier)))
         (call_expression (simple_identifier) (call_suffix (value_arguments)))
@@ -423,13 +424,13 @@ if a == b {
 ---
 
 (source_file
-    (if_expression
+    (if_statement
         (value_binding_pattern (non_binding_pattern (simple_identifier)))
         (simple_identifier)
-        (if_expression (value_binding_pattern (non_binding_pattern (simple_identifier))) (simple_identifier)))
-    (if_expression
+        (if_statement (value_binding_pattern (non_binding_pattern (simple_identifier))) (simple_identifier)))
+    (if_statement
         (equality_expression (simple_identifier) (simple_identifier))
-        (if_expression
+        (if_statement
             (value_binding_pattern (non_binding_pattern (simple_identifier)))
             (simple_identifier))))
 
@@ -501,11 +502,11 @@ if #available(macOS 10.12.0, *) {
 
 ---
 (source_file
-    (if_expression (availability_condition
+    (if_statement (availability_condition
         (identifier (simple_identifier))
         (integer_literal) (integer_literal))
         (statements (call_expression (simple_identifier) (call_suffix (value_arguments)))))
-    (if_expression (availability_condition
+    (if_statement (availability_condition
         (identifier (simple_identifier))
         (integer_literal) (integer_literal) (integer_literal))
         (statements (control_transfer_statement (integer_literal)))

--- a/grammar.js
+++ b/grammar.js
@@ -536,10 +536,7 @@ module.exports = grammar({
         $.dictionary_literal,
         $.self_expression,
         $.super_expression,
-        $.if_expression,
         $.guard_expression,
-        $.switch_expression,
-        $.do_expression,
         $.try_expression,
         $._referenceable_operator,
         alias($._three_dot_operator, $.fully_open_range)
@@ -647,9 +644,9 @@ module.exports = grammar({
 
     super_expression: ($) => seq("super"),
 
-    _else_options: ($) => choice($._block, $.if_expression),
+    _else_options: ($) => choice($._block, $.if_statement),
 
-    if_expression: ($) =>
+    if_statement: ($) =>
       prec.right(
         seq(
           "if",
@@ -678,7 +675,7 @@ module.exports = grammar({
         )
       ),
 
-    switch_expression: ($) =>
+    switch_statement: ($) =>
       seq("switch", $._expression, "{", repeat($.switch_entry), "}"),
 
     switch_entry: ($) =>
@@ -696,7 +693,7 @@ module.exports = grammar({
 
     switch_pattern: ($) => generate_pattern_matching_rule($, true, false, true),
 
-    do_expression: ($) => seq("do", $._block, repeat($.catch_block)),
+    do_statement: ($) => seq("do", $._block, repeat($.catch_block)),
 
     catch_block: ($) =>
       seq(
@@ -762,7 +759,7 @@ module.exports = grammar({
       choice(
         $._expression,
         $._declaration,
-        $._loop_statement,
+        $._labeled_statement,
         $.control_transfer_statement,
         $.assignment,
         $.availability_condition
@@ -770,13 +767,20 @@ module.exports = grammar({
 
     _block: ($) => prec(PREC.BLOCK, seq("{", optional($.statements), "}")),
 
-    _loop_statement: ($) =>
+    _labeled_statement: ($) =>
       seq(
-        optional($.loop_label),
-        choice($.for_statement, $.while_statement, $.repeat_while_statement)
+        optional($.statement_label),
+        choice(
+          $.for_statement,
+          $.while_statement,
+          $.repeat_while_statement,
+          $.do_statement,
+          $.if_statement,
+          $.switch_statement
+        )
       ),
 
-    loop_label: ($) => token(/[a-zA-Z_][a-zA-Z_0-9]*:/),
+    statement_label: ($) => token(/[a-zA-Z_][a-zA-Z_0-9]*:/),
 
     for_statement: ($) =>
       prec.right(
@@ -899,6 +903,7 @@ module.exports = grammar({
       prec.right(
         seq(
           optional($.modifiers),
+          optional("class"),
           choice("let", "var"),
           sep1(
             seq(

--- a/script-data/known_failures.txt
+++ b/script-data/known_failures.txt
@@ -28,9 +28,6 @@ Carthage/Source/CarthageKit/Git.swift
 Carthage/Tests/CarthageKitTests/DependencySpec.swift
 Carthage/Tests/CarthageKitTests/CartfileCommentsSpec.swift
 Carthage/Tests/CarthageKitTests/XcodeSpec.swift
-Moya/Tests/MoyaTests/TestHelpers.swift
-Moya/Sources/Moya/Plugins/NetworkLoggerPlugin.swift
-Moya/Sources/Moya/Response.swift
 ObjectMapper/Package@swift-4.swift
 ObjectMapper/Sources/HexColorTransform.swift
 ObjectMapper/Sources/ToJSON.swift


### PR DESCRIPTION
Fixes #27

To avoid parsing ambiguity, this commit also switches if/switch/do over
from being expressions to being statements. That's how they actually are
in the official grammar, but it didn't cause issues before to make them
expressions and it was strictly more flexible. Unfortunately that
flexibility is now over!
