### PR TITLE
Properly support metatypes

### DIFF
--- a/corpus/types.txt
+++ b/corpus/types.txt
@@ -207,3 +207,36 @@ public typealias IntCallback = Callback<T>
         (modifiers (visibility_modifier))
         (type_identifier)
         (user_type (type_identifier) (type_arguments (user_type (type_identifier))))))
+
+===
+Metatypes
+===
+
+_ = foo as [String].Type
+
+protocol GetType {
+   func getType() -> AnyObject.Type
+}
+
+---
+
+(source_file
+  (assignment
+    (directly_assignable_expression
+      (simple_identifier))
+    (navigation_expression
+      (as_expression
+        (simple_identifier)
+        (array_type
+          (user_type
+            (type_identifier))))
+      (navigation_suffix
+            (simple_identifier))))
+      (protocol_declaration
+        (type_identifier)
+        (protocol_body
+          (protocol_function_declaration
+            (simple_identifier)
+            (user_type
+              (type_identifier)
+              (type_identifier))))))

--- a/grammar.js
+++ b/grammar.js
@@ -242,18 +242,19 @@ module.exports = grammar({
       seq(sep1($._type, "&"), optional(token.immediate("!"))),
 
     _type: ($) =>
+      prec.right(seq(optional($.type_modifiers), $._unannotated_type)),
+
+    _unannotated_type: ($) =>
       prec.right(
-        seq(
-          optional($.type_modifiers),
-          choice(
-            $.user_type,
-            $.tuple_type,
-            $.function_type,
-            $.array_type,
-            $.dictionary_type,
-            $.optional_type,
-            $._opaque_type
-          )
+        choice(
+          $.user_type,
+          $.tuple_type,
+          $.function_type,
+          $.array_type,
+          $.dictionary_type,
+          $.optional_type,
+          $.metatype,
+          $._opaque_type
         )
       ),
 
@@ -299,6 +300,9 @@ module.exports = grammar({
           repeat1($._immediate_quest)
         )
       ),
+
+    metatype: ($) =>
+      prec.left(seq($._unannotated_type, ".", choice("Type", "Protocol"))),
 
     _quest: ($) => "?",
     _immediate_quest: ($) => token.immediate("?"),

--- a/script-data/known_failures.txt
+++ b/script-data/known_failures.txt
@@ -1,6 +1,5 @@
 Alamofire/Example/Source/AppDelegate.swift
 Alamofire/Tests/SessionManagerTests.swift
-lottie-ios/lottie-swift/src/Private/Model/Extensions/KeyedDecodingContainerExtensions.swift
 lottie-ios/lottie-swift/src/Private/Utility/Primitives/BezierPath.swift
 lottie-ios/lottie-swift/src/Private/Utility/Primitives/CompoundBezierPath.swift
 vapor/Sources/Vapor/Middleware/CORSMiddleware.swift

--- a/script-data/top-repositories.txt
+++ b/script-data/top-repositories.txt
@@ -1,6 +1,7 @@
 Alamofire Alamofire/Alamofire 4.8.2
 lottie-ios airbnb/lottie-ios 3.1.4
 vapor vapor/vapor 3.3.3
+SwiftyJSON SwiftyJSON/SwiftyJSON 5.0.1
 Kingfisher onevcat/Kingfisher 6.3.1
 shadowsocks shadowsocks/ShadowsocksX-NG v1.9.4
 Carthage Carthage/Carthage 0.38.0


### PR DESCRIPTION
Fixes #19

Previous code just pretended metatypes didn't exist, trivially handling
the simple case since `Foo.Type` could just be a type itself. However,
that breaks down in more complex cases like array types. This just makes
the metatype explicit as something that can have `.Type` or `.Protocol`
at the end of it.
