### PR TITLE
Add a few more items to the `_semi`-suppressor

### DIFF
--- a/corpus/classes.txt
+++ b/corpus/classes.txt
@@ -404,6 +404,7 @@ protocol Fallible {
     associatedtype SuccessType = Void
 
     func getFailure() -> Self.FailureType?
+        where Self.FailureType: Equatable
 }
 
 public protocol FooProvider {
@@ -424,7 +425,14 @@ protocol Wrapper {
             (associatedtype_declaration (type_identifier) (user_type (type_identifier)))
             (protocol_function_declaration
                 (simple_identifier)
-                (optional_type (user_type (type_identifier) (type_identifier))))))
+                (optional_type (user_type (type_identifier) (type_identifier)))
+                (type_constraints
+                    (type_constraint
+                        (inheritance_constraint
+                            (identifier
+                                  (simple_identifier)
+                                  (simple_identifier))
+                            (user_type (type_identifier))))))))
     (protocol_declaration
         (modifiers (visibility_modifier))
         (type_identifier)

--- a/corpus/statements.txt
+++ b/corpus/statements.txt
@@ -418,7 +418,8 @@ if let aPrime = a {
 }
 
 if a == b {
-} else if let cPrime = c {
+}
+else if let cPrime = c {
 }
 
 ---

--- a/grammar.js
+++ b/grammar.js
@@ -112,6 +112,8 @@ module.exports = grammar({
     $._throws_keyword,
     $._rethrows_keyword,
     $.default_keyword,
+    $._where_keyword,
+    $._else,
   ],
 
   rules: {
@@ -656,7 +658,7 @@ module.exports = grammar({
         seq(
           "if",
           sep1(prec.left($._if_condition_sequence_item), ","),
-          choice($._block, seq($._block, "else", $._else_options))
+          choice($._block, seq($._block, $._else, $._else_options))
         )
       ),
 
@@ -675,7 +677,7 @@ module.exports = grammar({
         seq(
           "guard",
           sep1(prec.left($._if_condition_sequence_item), ","),
-          "else",
+          $._else,
           $._block
         )
       ),
@@ -690,7 +692,7 @@ module.exports = grammar({
           seq("case", $.switch_pattern, repeat(seq(",", $.switch_pattern))),
           $.default_keyword
         ),
-        optional(seq("where", $._expression)),
+        optional(seq($._where_keyword, $._expression)),
         ":",
         $.statements,
         optional("fallthrough")
@@ -708,7 +710,7 @@ module.exports = grammar({
         $._block
       ),
 
-    where_clause: ($) => prec.left(seq("where", $._expression)),
+    where_clause: ($) => prec.left(seq($._where_keyword, $._expression)),
 
     try_expression: ($) =>
       prec.left(
@@ -1042,7 +1044,7 @@ module.exports = grammar({
       ),
 
     type_constraints: ($) =>
-      prec.right(seq("where", sep1($.type_constraint, ","))),
+      prec.right(seq($._where_keyword, sep1($.type_constraint, ","))),
 
     type_constraint: ($) =>
       choice($.inheritance_constraint, $.equality_constraint),

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -17,10 +17,12 @@ enum TokenType {
     EQUAL_SIGN,
     THROWS_KEYWORD,
     RETHROWS_KEYWORD,
-    DEFAULT_KEYWORD
+    DEFAULT_KEYWORD,
+    WHERE_KEYWORD,
+    ELSE_KEYWORD
 };
 
-#define CROSS_SEMI_OPERATOR_COUNT 11
+#define CROSS_SEMI_OPERATOR_COUNT 13
 
 const char* CROSS_SEMI_OPERATORS[CROSS_SEMI_OPERATOR_COUNT] = {
     "->",
@@ -33,7 +35,9 @@ const char* CROSS_SEMI_OPERATORS[CROSS_SEMI_OPERATOR_COUNT] = {
     "=",
     "throws",
     "rethrows",
-    "default"
+    "default",
+    "where",
+    "else"
 };
 
 const int32_t CROSS_SEMI_OP_LENS[CROSS_SEMI_OPERATOR_COUNT] = {
@@ -47,7 +51,9 @@ const int32_t CROSS_SEMI_OP_LENS[CROSS_SEMI_OPERATOR_COUNT] = {
     1,
     6,
     8,
-    7
+    7,
+    5,
+    4
 };
 
 const enum TokenType CROSS_SEMI_SYMBOLS[CROSS_SEMI_OPERATOR_COUNT] = {
@@ -61,7 +67,9 @@ const enum TokenType CROSS_SEMI_SYMBOLS[CROSS_SEMI_OPERATOR_COUNT] = {
     EQUAL_SIGN,
     THROWS_KEYWORD,
     RETHROWS_KEYWORD,
-    DEFAULT_KEYWORD
+    DEFAULT_KEYWORD,
+    WHERE_KEYWORD,
+    ELSE_KEYWORD
 };
 
 struct ScannerState {


### PR DESCRIPTION
Fixes #15 adding `else` to the list of keywords that the custom scanner
will use to skip `_semi` tokens.

Also, just like `throws` and `rethrows`, a where clause may dangle off
of the end of a function declaration. The declaration will look
syntactically valid without it, but then when the parser encounters the
`where`, everything will blow up.

This handles `where` the same as the other keywords that have this
problem by moving it to the custom scanner.
