### PR TITLE
Fix tuple expressions being too low in precedence

### DIFF
--- a/corpus/expressions.txt
+++ b/corpus/expressions.txt
@@ -548,3 +548,24 @@ let nestedKeyPath = \OuterStructure.outer.someValue
       (navigation_suffix
         (simple_identifier)))))
 
+===
+Tuple expression in function
+===
+
+trimPathAtLengths(positions: [(start: start, end: end)])
+
+---
+
+(source_file
+  (call_expression
+    (simple_identifier)
+    (call_suffix
+      (value_arguments
+        (value_argument
+          (simple_identifier)
+          (array_literal
+            (tuple_expression
+              (simple_identifier)
+              (simple_identifier)
+              (simple_identifier)
+              (simple_identifier))))))))

--- a/grammar.js
+++ b/grammar.js
@@ -86,6 +86,9 @@ module.exports = grammar({
     // { (foo, bar) ...
     [$._expression, $._lambda_parameter],
     [$._primary_expression, $._lambda_parameter],
+
+    // (start: start, end: end)
+    [$._tuple_type_item_identifier, $.tuple_expression],
   ],
 
   extras: ($) => [
@@ -551,7 +554,6 @@ module.exports = grammar({
 
     tuple_expression: ($) =>
       prec.left(
-        -1,
         seq(
           "(",
           sep1(

--- a/script-data/known_failures.txt
+++ b/script-data/known_failures.txt
@@ -1,7 +1,5 @@
 Alamofire/Example/Source/AppDelegate.swift
 Alamofire/Tests/SessionManagerTests.swift
-lottie-ios/lottie-swift/src/Private/Utility/Primitives/BezierPath.swift
-lottie-ios/lottie-swift/src/Private/Utility/Primitives/CompoundBezierPath.swift
 shadowsocks/ShadowsocksX-NG/ServerProfile.swift
 Carthage/Source/carthage/Outdated.swift
 Carthage/Source/carthage/Archive.swift


### PR DESCRIPTION
Fixes #20

Turns out declaring a conflict between tuple expressions and tuple types
is unavoidable after all.
