### PR TITLE
Add some unicode identifier support (no emojis)

### DIFF
--- a/corpus/statements.txt
+++ b/corpus/statements.txt
@@ -513,3 +513,21 @@ if #available(macOS 10.12.0, *) {
         (statements (control_transfer_statement (integer_literal)))
         (statements (control_transfer_statement (integer_literal)))))
 
+
+===
+Unicode identifiers
+===
+
+let ø = unicode()
+
+---
+
+(source_file
+  (property_declaration
+    (value_binding_pattern
+      (non_binding_pattern
+        (simple_identifier)))
+    (call_expression
+      (simple_identifier)
+      (call_suffix
+        (value_arguments)))))

--- a/grammar.js
+++ b/grammar.js
@@ -48,7 +48,7 @@ const HEX_DIGITS = token(sep1(/[0-9a-fA-F]+/, /_+/));
 const OCT_DIGITS = token(sep1(/[0-7]+/, /_+/));
 const BIN_DIGITS = token(sep1(/[01]+/, /_+/));
 const REAL_EXPONENT = token(seq(/[eE]/, optional(/[+-]/), DEC_DIGITS));
-const LEXICAL_IDENTIFIER = /[a-zA-Z_][a-zA-Z_0-9]*/;
+const LEXICAL_IDENTIFIER = /[_\p{XID_Start}][_\p{XID_Continue}]*/;
 const CUSTOM_OPERATORS = token(
   choice(
     // https://docs.swift.org/swift-book/ReferenceManual/LexicalStructure.html#ID418

--- a/script-data/known_failures.txt
+++ b/script-data/known_failures.txt
@@ -9,11 +9,9 @@ Carthage/Source/carthage/Fetch.swift
 Carthage/Source/carthage/Build.swift
 Carthage/Source/carthage/Checkout.swift
 Carthage/Source/carthage/Formatting.swift
-Carthage/Source/CarthageKit/Simulator.swift
 Carthage/Source/CarthageKit/Archive.swift
 Carthage/Source/CarthageKit/VersionFile.swift
 Carthage/Source/CarthageKit/Project.swift
-Carthage/Source/CarthageKit/FrameworkExtensions.swift
 Carthage/Source/CarthageKit/GitURL.swift
 Carthage/Source/CarthageKit/Git.swift
 Carthage/Tests/CarthageKitTests/DependencySpec.swift


### PR DESCRIPTION
Fixes #4 (good enough)

Uses XID_Start and XID_Continue to add support for a broader set of
unicode identifiers. Notably this doesn't include emojis even though
Swift does. I haven't seen any projects use emojis so this is probably
good enough for now.
