### PR TITLE
Special case navigation with force unwrap

### DIFF
--- a/corpus/expressions.txt
+++ b/corpus/expressions.txt
@@ -569,3 +569,39 @@ trimPathAtLengths(positions: [(start: start, end: end)])
               (simple_identifier)
               (simple_identifier)
               (simple_identifier))))))))
+
+===
+Navigation expressions
+===
+
+_ = self.foo.bar.baz
+print(thing.maybeGreeting!.definitely)
+
+---
+
+(source_file
+  (assignment
+    (directly_assignable_expression
+      (simple_identifier))
+    (navigation_expression
+      (navigation_expression
+        (navigation_expression
+          (self_expression)
+          (navigation_suffix
+            (simple_identifier)))
+        (navigation_suffix
+          (simple_identifier)))
+      (navigation_suffix
+        (simple_identifier))))
+  (call_expression
+    (simple_identifier)
+    (call_suffix
+      (value_arguments
+        (value_argument
+          (navigation_expression
+            (navigation_expression
+              (simple_identifier)
+              (navigation_suffix
+                (simple_identifier)))
+            (navigation_suffix
+              (simple_identifier))))))))

--- a/grammar.js
+++ b/grammar.js
@@ -479,9 +479,13 @@ module.exports = grammar({
 
     navigation_suffix: ($) =>
       seq(
-        $._dot_operator,
+        $._navigation_operator,
         choice($.simple_identifier, $.tuple_expression, $.integer_literal)
       ),
+
+    // `!.` should just be the result of a postfix `!` before navigation, but it gets parsed as a
+    // custom infix operator instead.
+    _navigation_operator: ($) => choice($._dot_operator, "!."),
 
     call_suffix: ($) =>
       prec.left(

--- a/script-data/known_failures.txt
+++ b/script-data/known_failures.txt
@@ -1,5 +1,3 @@
-Alamofire/Example/Source/AppDelegate.swift
-Alamofire/Tests/SessionManagerTests.swift
 shadowsocks/ShadowsocksX-NG/ServerProfile.swift
 Carthage/Source/carthage/Outdated.swift
 Carthage/Source/carthage/Archive.swift


### PR DESCRIPTION
Fixes #16

Force unwrapping during navigation _should_ just fall naturally out of
the normal postfix operator combined with a basic navigation expression.
Unfortunately, life isn't that simple, and it gets parsed as a custom
infix operator instead. We can nudge things in the right direction by
just declaring a `!.` operator, even though no such operator truly
exists.
