### PR TITLE
Prevent comments from occurring in strings

### DIFF
--- a/corpus/literals.txt
+++ b/corpus/literals.txt
@@ -30,12 +30,14 @@ String literals
 This is a "multiline"
 string.
 """
+"This string has a // comment (except not!)"
 
 ---
 
 (source_file
     (line_string_literal)
-    (multi_line_string_literal))
+    (multi_line_string_literal)
+    (line_string_literal))
 
 ==================
 String interpolation

--- a/grammar.js
+++ b/grammar.js
@@ -133,7 +133,7 @@ module.exports = grammar({
     // Lexical Structure - https://docs.swift.org/swift-book/ReferenceManual/LexicalStructure.html
     ////////////////////////////////
 
-    comment: ($) => prec(PREC.COMMENT, seq("//", /.*/)),
+    comment: ($) => token(prec(PREC.COMMENT, seq("//", /.*/))),
 
     // Identifiers
 

--- a/script-data/known_failures.txt
+++ b/script-data/known_failures.txt
@@ -1,4 +1,3 @@
-shadowsocks/ShadowsocksX-NG/ServerProfile.swift
 Carthage/Source/carthage/Outdated.swift
 Carthage/Source/carthage/Archive.swift
 Carthage/Source/carthage/Update.swift


### PR DESCRIPTION
Uses the approach described in:
https://github.com/tree-sitter/tree-sitter/issues/1087
