### PR TITLE
Support protocol composition in inheritance clauses

### DIFF
--- a/corpus/classes.txt
+++ b/corpus/classes.txt
@@ -242,7 +242,7 @@ Inheritance
 
 class A : B {}
 
-class D : SomeInterface { }
+class D : Protocol1 & Protocol2 { }
 
 ---
 
@@ -253,6 +253,7 @@ class D : SomeInterface { }
         (class_body))
     (class_declaration
         (type_identifier)
+        (inheritance_specifier (user_type (type_identifier)))
         (inheritance_specifier (user_type (type_identifier)))
         (class_body)))
 

--- a/grammar.js
+++ b/grammar.js
@@ -1032,7 +1032,7 @@ module.exports = grammar({
     class_body: ($) => seq("{", optional($._class_member_declarations), "}"),
 
     _inheritance_specifiers: ($) =>
-      prec.left(sep1($.inheritance_specifier, ",")),
+      prec.left(sep1($.inheritance_specifier, choice(",", "&"))),
 
     inheritance_specifier: ($) =>
       prec.left(choice($.user_type, $.function_type)),

--- a/script-data/top-repositories.txt
+++ b/script-data/top-repositories.txt
@@ -1,8 +1,8 @@
-Alamofire Alamofire/Alamofire 4.8.2
-lottie-ios airbnb/lottie-ios 3.1.4
+Alamofire Alamofire/Alamofire 5.4.4
+lottie-ios airbnb/lottie-ios 3.2.3
 vapor vapor/vapor 3.3.3
 SwiftyJSON SwiftyJSON/SwiftyJSON 5.0.1
-Kingfisher onevcat/Kingfisher 6.3.1
+Kingfisher onevcat/Kingfisher 7.1.1
 shadowsocks shadowsocks/ShadowsocksX-NG v1.9.4
 Carthage Carthage/Carthage 0.38.0
 Moya Moya/Moya 15.0.0


### PR DESCRIPTION
Newer versions of Alamofire use `class Foo: Bar & Baz`. Adding that as a
separator in inheritance clauses lets us bump the tag we have in
top-repos. While I'm at it, bumped other versions as well.
