### PR TITLE
Grand renaming and 0.1-ing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
-name = "experimental-tree-sitter-swift"
+name = "tree-sitter-swift"
 description = "swift grammar for the tree-sitter parsing library"
-version = "0.0.3"
+version = "0.1.0"
 keywords = ["incremental", "parsing", "swift"]
 categories = ["parsing", "text-editors"]
-repository = "https://github.com/alex-pinkus/experimental-tree-sitter-swift"
+repository = "https://github.com/alex-pinkus/tree-sitter-swift"
 edition = "2018"
 license = "MIT"
 

--- a/README.md
+++ b/README.md
@@ -1,12 +1,11 @@
-![Parse rate badge](https://byob.yarr.is/alex-pinkus/experimental-tree-sitter-swift/parse_rate)
-[![Crates.io badge](https://byob.yarr.is/alex-pinkus/experimental-tree-sitter-swift/crates_io_version)](https://crates.io/crates/experimental-tree-sitter-swift)
-[![NPM badge](https://byob.yarr.is/alex-pinkus/experimental-tree-sitter-swift/npm_version)](https://www.npmjs.com/package/experimental-tree-sitter-swift)
-[![Build](https://github.com/alex-pinkus/experimental-tree-sitter-swift/actions/workflows/top-repos.yml/badge.svg)](https://github.com/alex-pinkus/experimental-tree-sitter-swift/actions/workflows/top-repos.yml)
+![Parse rate badge](https://byob.yarr.is/alex-pinkus/tree-sitter-swift/parse_rate)
+[![Crates.io badge](https://byob.yarr.is/alex-pinkus/tree-sitter-swift/crates_io_version)](https://crates.io/crates/tree-sitter-swift)
+[![NPM badge](https://byob.yarr.is/alex-pinkus/tree-sitter-swift/npm_version)](https://www.npmjs.com/package/tree-sitter-swift)
+[![Build](https://github.com/alex-pinkus/tree-sitter-swift/actions/workflows/top-repos.yml/badge.svg)](https://github.com/alex-pinkus/tree-sitter-swift/actions/workflows/top-repos.yml)
 
-# experimental-tree-sitter-swift
+# tree-sitter-swift
 
-This contains an experimental [`tree-sitter`](https://tree-sitter.github.io/tree-sitter) grammar for the Swift
-programming language.
+This contains a [`tree-sitter`](https://tree-sitter.github.io/tree-sitter) grammar for the Swift programming language.
 
 ## Getting started
 
@@ -16,14 +15,14 @@ To use this parser to parse Swift code, you'll want to depend on either the Rust
 To use the Rust crate, you'll add this to your `Cargo.toml`:
 ```
 tree-sitter = "0.20.0"
-experimental-tree-sitter-swift = "=0.0.3"
+tree-sitter-swift = "=0.1.0"
 ```
 
 Then you can use a `tree-sitter` parser with the language declared here:
 
 ```
 let mut parser = tree_sitter::Parser::new();
-parser.set_language(experimental_tree_sitter_swift::language())?;
+parser.set_language(tree_sitter_swift::language())?;
 
 // ...
 
@@ -36,7 +35,7 @@ let tree = parser.parse(&my_source_code, None)
 To use this from NPM, you'll add similar dependencies to `package.json`:
 ```
 "dependencies: {
-  "experimental-tree-sitter-swift": "0.0.3",
+  "tree-sitter-swift": "0.1.0",
   "tree-sitter": "^0.20.0"
 }
 ```
@@ -44,7 +43,7 @@ To use this from NPM, you'll add similar dependencies to `package.json`:
 Your usage of the parser will look like:
 ```
 const Parser = require("tree-sitter");
-const Swift = require("experimental-tree-sitter-swift");
+const Swift = require("tree-sitter-swift");
 
 const parser = new Parser();
 parser.setLanguage(Swift);
@@ -65,12 +64,6 @@ substitute `tree-sitter test` directly.
 3. Run `tree-sitter parse` on some real Swift codebase and see whether (or where) it fails.
 4. Use any failures to create new corpus test cases.
 
-If you simply want to _use_ the parser, and not modify it, you can depend on it from Rust code using the instructions in
-the [rust bindings README](https://github.com/tree-sitter/tree-sitter/blob/master/lib/binding_rust/README.md).
-Basically, you'll want to build the `parser.c` and `scanner.c` in your build script and use the generated files to
-produce a parser that the bindings can interact with. I don't plan to publish this as a crate while it's still in the
-`experimental` state.
-
 ## Contributions
 
 If you have a change to make to this parser, and the change is a net positive, please submit a pull request. I mostly
@@ -79,37 +72,6 @@ you have an issue with the parser, please file a bug and include a test case to 
 level of support, but having the test case makes it more likely that I want to tinker with it.
 
 ## Frequently asked questions
-
-### Isn't there already a Swift grammar? Why did you create another one?
-
-There is a Swift grammar that lives under the `tree-sitter` org, but it doesn't have a `LICENSE` file. Since it's not
-licensed, I would have to be cautious about using it myself. I actually haven't looked at the code itself, or the
-repository much at all, since I want to avoid potential licensing issues with this parser. A brief scan of the Github
-issues tells me it's also not quite complete, but I haven't done a deep dive to see whether it's more complete than this
-one.
-
-I created this parser to learn how to use tree-sitter. Looking at the landscape, it seemed like it might be useful to
-others, so I decided to publish it. Since this has a permissive license, it seems like a good path forward for anyone
-else whose needs are similar to my own.
-
-### If this isn't a fork of the existing Swift grammar, what is it based on?
-
-A lot of specific features were based off of the [Kotlin language grammar](https://github.com/fwcd/tree-sitter-kotlin),
-since the two have many cosmetic similarities. For instance, both languages have trailing closure syntax. Some parts
-also come from the [Rust grammar](https://github.com/tree-sitter/tree-sitter-rust), which this grammar should probably
-copy more of.
-
-### Why is this `experimental`? What's experimental about it?
-
-That's a question that remains to be answered. If this grammar doesn't get used much, it will probably be experimental
-forever. If there's interest in it, hopefully others are willing to help define what it would take to make this not
-"experimental". Reaching a point where we can offer some stability guarantees is probably a good first step.
-
-### What stability guarantees do you offer?
-
-Currently none. It seems prudent that someday, the grammar would be versioned and any removal or changes to nodes would
-be considered a breaking change, and accompanied by a major version bump. Right now, this is not the place to go for
-stability unless you pin an exact commit hash.
 
 ### Where is your `parser.c`?
 
@@ -124,7 +86,7 @@ and your library version are compatible.
 
 If you need a `parser.c`, and you don't care about the tree-sitter version, but you don't have a local setup that would
 allow you to obtain the parser, you can just download one from a recent workflow run in this package. To do so:
-* Go to the [GitHub actions page](https://github.com/alex-pinkus/experimental-tree-sitter-swift/actions) for this
+* Go to the [GitHub actions page](https://github.com/alex-pinkus/tree-sitter-swift/actions) for this
   repository.
 * Click on the "Check grammar and style" action for the appropriate commit.
 * Go down to `Artifacts` and click on `generated-parser-src`. All the relevant parser files will be available in your

--- a/bindings/rust/lib.rs
+++ b/bindings/rust/lib.rs
@@ -6,7 +6,7 @@
 //! ```
 //! let code = "";
 //! let mut parser = tree_sitter::Parser::new();
-//! parser.set_language(experimental_tree_sitter_swift::language()).expect("Error loading swift grammar");
+//! parser.set_language(tree_sitter_swift::language()).expect("Error loading swift grammar");
 //! let tree = parser.parse(code, None).unwrap();
 //! ```
 //!

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,12 @@
 {
-  "name": "experimental-tree-sitter-swift",
-  "version": "0.0.2",
+  "name": "tree-sitter-swift",
+  "version": "0.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "0.0.2",
+      "name": "tree-sitter-swift",
+      "version": "0.1.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "experimental-tree-sitter-swift",
-  "version": "0.0.3",
-  "description": "An experimental tree-sitter grammar for the Swift programming language.",
+  "name": "tree-sitter-swift",
+  "version": "0.1.0",
+  "description": "A tree-sitter grammar for the Swift programming language.",
   "main": "bindings/node/index.js",
   "scripts": {
     "install": "tsc && tree-sitter generate ./build/grammar.js",
@@ -12,7 +12,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/alex-pinkus/experimental-tree-sitter-swift.git"
+    "url": "git+https://github.com/alex-pinkus/tree-sitter-swift.git"
   },
   "keywords": [
     "parser",
@@ -21,9 +21,9 @@
   "author": "Alex Pinkus <alex.pinkus@gmail.com>",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/alex-pinkus/experimental-tree-sitter-swift/issues"
+    "url": "https://github.com/alex-pinkus/tree-sitter-swift/issues"
   },
-  "homepage": "https://github.com/alex-pinkus/experimental-tree-sitter-swift#readme",
+  "homepage": "https://github.com/alex-pinkus/tree-sitter-swift#readme",
   "dependencies": {
     "@types/node": "^16.11.10",
     "nan": "^2.15.0",

--- a/test-npm-package/index.js
+++ b/test-npm-package/index.js
@@ -1,5 +1,5 @@
 const Parser = require("tree-sitter");
-const Swift = require("experimental-tree-sitter-swift");
+const Swift = require("tree-sitter-swift");
 
 const parser = new Parser();
 parser.setLanguage(Swift);

--- a/test-npm-package/package-lock.json
+++ b/test-npm-package/package-lock.json
@@ -9,12 +9,13 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "experimental-tree-sitter-swift": "file:../",
-        "tree-sitter": "^0.20.0"
+        "tree-sitter": "^0.20.0",
+        "tree-sitter-swift": "file:../"
       }
     },
     "..": {
-      "version": "0.0.3",
+      "name": "tree-sitter-swift",
+      "version": "0.1.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -188,10 +189,6 @@
       "engines": {
         "node": ">=6"
       }
-    },
-    "node_modules/experimental-tree-sitter-swift": {
-      "resolved": "..",
-      "link": true
     },
     "node_modules/fs-constants": {
       "version": "1.0.0",
@@ -551,6 +548,10 @@
         "prebuild-install": "^6.0.1"
       }
     },
+    "node_modules/tree-sitter-swift": {
+      "resolved": "..",
+      "link": true
+    },
     "node_modules/tunnel-agent": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
@@ -692,17 +693,6 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
       "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg=="
-    },
-    "experimental-tree-sitter-swift": {
-      "version": "file:..",
-      "requires": {
-        "@types/node": "^16.11.10",
-        "nan": "^2.15.0",
-        "node-gyp": "^8.4.1",
-        "prettier": "2.3.2",
-        "tree-sitter-cli": "^0.20.0",
-        "typescript": "^4.5.2"
-      }
     },
     "fs-constants": {
       "version": "1.0.0",
@@ -991,6 +981,17 @@
       "requires": {
         "nan": "^2.14.0",
         "prebuild-install": "^6.0.1"
+      }
+    },
+    "tree-sitter-swift": {
+      "version": "file:..",
+      "requires": {
+        "@types/node": "^16.11.10",
+        "nan": "^2.15.0",
+        "node-gyp": "^8.4.1",
+        "prettier": "2.3.2",
+        "tree-sitter-cli": "^0.20.0",
+        "typescript": "^4.5.2"
       }
     },
     "tunnel-agent": {

--- a/test-npm-package/package.json
+++ b/test-npm-package/package.json
@@ -9,7 +9,7 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "experimental-tree-sitter-swift": "file:../",
-    "tree-sitter": "^0.20.0"
+    "tree-sitter": "^0.20.0",
+    "tree-sitter-swift": "file:../"
   }
 }


### PR DESCRIPTION
It turns out (#92) that some libraries rely on the name of the `tree-sitter` packages always being `tree-sitter-.*`. Rather than trying to take some secondary title of `experimental-swift` or similar, we can simply drop the `experimental` and bring balance to the force.

Fixes #92
