### PR TITLE
Add an alias for `?` in type position

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tree-sitter-swift"
 description = "swift grammar for the tree-sitter parsing library"
-version = "0.1.1"
+version = "0.1.2"
 keywords = ["incremental", "parsing", "swift"]
 categories = ["parsing", "text-editors"]
 repository = "https://github.com/alex-pinkus/tree-sitter-swift"

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ To use this parser to parse Swift code, you'll want to depend on either the Rust
 To use the Rust crate, you'll add this to your `Cargo.toml`:
 ```
 tree-sitter = "0.20.0"
-tree-sitter-swift = "=0.1.1"
+tree-sitter-swift = "=0.1.2"
 ```
 
 Then you can use a `tree-sitter` parser with the language declared here:
@@ -35,7 +35,7 @@ let tree = parser.parse(&my_source_code, None)
 To use this from NPM, you'll add similar dependencies to `package.json`:
 ```
 "dependencies: {
-  "tree-sitter-swift": "0.1.1",
+  "tree-sitter-swift": "0.1.2",
   "tree-sitter": "^0.20.0"
 }
 ```

--- a/grammar.ts
+++ b/grammar.ts
@@ -454,7 +454,7 @@ module.exports = grammar({
             "wrapped",
             choice($.user_type, $.tuple_type, $.array_type, $.dictionary_type)
           ),
-          repeat1($._immediate_quest)
+          repeat1(alias($._immediate_quest, "?"))
         )
       ),
 
@@ -488,7 +488,7 @@ module.exports = grammar({
           $.ternary_expression,
           $._primary_expression,
           $.assignment,
-          seq($._expression, $._immediate_quest)
+          seq($._expression, alias($._immediate_quest, "?"))
         )
       ),
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tree-sitter-swift",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "tree-sitter-swift",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tree-sitter-swift",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "A tree-sitter grammar for the Swift programming language.",
   "main": "bindings/node/index.js",
   "scripts": {

--- a/test-npm-package/package-lock.json
+++ b/test-npm-package/package-lock.json
@@ -15,7 +15,7 @@
     },
     "..": {
       "name": "tree-sitter-swift",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
Currently `?` is not visible in the syntax tree because it's anonymous.

Fixes #100
