### PR TITLE
Use ABI 14 for compilation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ include = [
 path = "bindings/rust/lib.rs"
 
 [dependencies]
-tree-sitter = "~0.20.0"
+tree-sitter = "0.20.3"
 
 [build-dependencies]
 cc = "1.0"

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ To use this parser to parse Swift code, you'll want to depend on either the Rust
 ### Rust
 To use the Rust crate, you'll add this to your `Cargo.toml`:
 ```
-tree-sitter = "0.20.0"
+tree-sitter = "0.20.3"
 tree-sitter-swift = "=0.1.2"
 ```
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
       "dependencies": {
         "@types/node": "^16.11.10",
         "nan": "^2.15.0",
-        "tree-sitter-cli": "^0.20.0"
+        "tree-sitter-cli": "^0.20.4"
       },
       "devDependencies": {
         "node-gyp": "^8.4.1",
@@ -964,9 +964,9 @@
       }
     },
     "node_modules/tree-sitter-cli": {
-      "version": "0.20.1",
-      "resolved": "https://registry.npmjs.org/tree-sitter-cli/-/tree-sitter-cli-0.20.1.tgz",
-      "integrity": "sha512-I0Gp4ThRp39TDnBAaZKiogvoE85MSeL6/ILZMXbzeEo8hUsudpVhEHRE4CU+Bk5QUaiMiDkD+ZIL3gT2zZ++wg==",
+      "version": "0.20.4",
+      "resolved": "https://registry.npmjs.org/tree-sitter-cli/-/tree-sitter-cli-0.20.4.tgz",
+      "integrity": "sha512-G42x0Ev7mxA8WLUfZY+two5LIhPf6R/m7qDZtKxOzE77zXi6didNI/vf17kHaKaRXJrWnyCxHFaVQFO2LL81yg==",
       "hasInstallScript": true,
       "bin": {
         "tree-sitter": "cli.js"
@@ -1769,9 +1769,9 @@
       }
     },
     "tree-sitter-cli": {
-      "version": "0.20.1",
-      "resolved": "https://registry.npmjs.org/tree-sitter-cli/-/tree-sitter-cli-0.20.1.tgz",
-      "integrity": "sha512-I0Gp4ThRp39TDnBAaZKiogvoE85MSeL6/ILZMXbzeEo8hUsudpVhEHRE4CU+Bk5QUaiMiDkD+ZIL3gT2zZ++wg=="
+      "version": "0.20.4",
+      "resolved": "https://registry.npmjs.org/tree-sitter-cli/-/tree-sitter-cli-0.20.4.tgz",
+      "integrity": "sha512-G42x0Ev7mxA8WLUfZY+two5LIhPf6R/m7qDZtKxOzE77zXi6didNI/vf17kHaKaRXJrWnyCxHFaVQFO2LL81yg=="
     },
     "unique-filename": {
       "version": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A tree-sitter grammar for the Swift programming language.",
   "main": "bindings/node/index.js",
   "scripts": {
-    "install": "tree-sitter generate",
+    "install": "tree-sitter generate --abi 14",
     "postinstall": "node-gyp configure && node-gyp build",
     "ci": "prettier --check grammar.js",
     "test-ci": "./scripts/test-with-memcheck.sh --install-valgrind",
@@ -27,7 +27,7 @@
   "dependencies": {
     "@types/node": "^16.11.10",
     "nan": "^2.15.0",
-    "tree-sitter-cli": "^0.20.0"
+    "tree-sitter-cli": "^0.20.4"
   },
   "devDependencies": {
     "node-gyp": "^8.4.1",


### PR DESCRIPTION
Now that `tree-sitter` version 0.20.4 has been out for a week, it's time
to start reaping the benefits. This updates to that version and adds the
`--abi` parameter to the `tree-sitter generate` command in
`npm install`. Anyone using `npm` for installation directly will fetch
the right version.
