### PR TITLE
Update top repository tag versions in CI

### DIFF
--- a/.github/workflows/update-repos.yml
+++ b/.github/workflows/update-repos.yml
@@ -1,0 +1,14 @@
+name: Update corpus repository versions
+
+on:
+  schedule:
+    - cron: '12 4 * * *'
+
+jobs:
+  update_repository_versions:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - run: ./scripts/update-top-repos.sh
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/script-data/known_failures.txt
+++ b/script-data/known_failures.txt
@@ -1,4 +1,15 @@
+Alamofire/Tests/ConcurrencyTests.swift
+Alamofire/Source/Concurrency.swift
 firefox-ios/Shared/Functions.swift
 RxSwift/RxExample/RxExample/Examples/GitHubSearchRepositories/GitHubSearchRepositories.swift
 RxSwift/Rx.playground/Pages/Transforming_Operators.xcplaygroundpage/Contents.swift
+RxSwift/RxCocoa/Traits/SharedSequence/SharedSequence+Concurrency.swift
+RxSwift/RxSwift/Traits/PrimitiveSequence/PrimitiveSequence+Concurrency.swift
+RxSwift/RxSwift/Traits/Infallible/Infallible+Concurrency.swift
+RxSwift/Sources/RxSwift/PrimitiveSequence+Concurrency.swift
+RxSwift/Sources/RxSwift/Observable+Concurrency.swift
+RxSwift/Sources/RxSwift/Infallible+Concurrency.swift
+RxSwift/Sources/RxCocoa/SharedSequence+Concurrency.swift
+RxSwift/RxSwift/Observable+Concurrency.swift
+SwiftLint/Source/SwiftLintFramework/Rules/Lint/ExpiringTodoRule.swift
 GRDB/GRDB/Core/Row.swift

--- a/script-data/top-repositories.txt
+++ b/script-data/top-repositories.txt
@@ -1,43 +1,43 @@
-Alamofire Alamofire/Alamofire 5.4.4
+Alamofire Alamofire/Alamofire 5.5.0
 iina iina/iina v1.2.0
 Charts danielgindi/Charts v4.0.1
-lottie-ios airbnb/lottie-ios 3.2.3
+lottie-ios airbnb/lottie-ios 3.3.0
 vapor vapor/vapor 3.3.3
 SwiftyJSON SwiftyJSON/SwiftyJSON 5.0.1
-RxSwift ReactiveX/RxSwift 6.2.0 0 9
-RxSwift ReactiveX/RxSwift 6.2.0 1 9
-RxSwift ReactiveX/RxSwift 6.2.0 2 9
-RxSwift ReactiveX/RxSwift 6.2.0 3 9
-RxSwift ReactiveX/RxSwift 6.2.0 4 9
-RxSwift ReactiveX/RxSwift 6.2.0 5 9
-RxSwift ReactiveX/RxSwift 6.2.0 6 9
-RxSwift ReactiveX/RxSwift 6.2.0 7 9
-RxSwift ReactiveX/RxSwift 6.2.0 8 9
+RxSwift ReactiveX/RxSwift 6.5.0 0 9
+RxSwift ReactiveX/RxSwift 6.5.0 1 9
+RxSwift ReactiveX/RxSwift 6.5.0 2 9
+RxSwift ReactiveX/RxSwift 6.5.0 3 9
+RxSwift ReactiveX/RxSwift 6.5.0 4 9
+RxSwift ReactiveX/RxSwift 6.5.0 5 9
+RxSwift ReactiveX/RxSwift 6.5.0 6 9
+RxSwift ReactiveX/RxSwift 6.5.0 7 9
+RxSwift ReactiveX/RxSwift 6.5.0 8 9
 HeroTransitions HeroTransitions/Hero 1.6.1
-Kingfisher onevcat/Kingfisher 7.1.1
+Kingfisher onevcat/Kingfisher 7.1.2
 shadowsocks shadowsocks/ShadowsocksX-NG v1.9.4
 SnapKit SnapKit/SnapKit 5.0.1
-SwiftLint realm/SwiftLint 0.45.0 0 2
-SwiftLint realm/SwiftLint 0.45.0 1 2
-ClashX yichengchen/clashX 1.72.0
+SwiftLint realm/SwiftLint 0.46.2 0 2
+SwiftLint realm/SwiftLint 0.46.2 1 2
+ClashX yichengchen/clashX 1.90.0
 Carthage Carthage/Carthage 0.38.0
-Rectangle rxhanson/Rectangle v0.49
-PromiseKit mxcl/PromiseKit 6.16.2
+Rectangle rxhanson/Rectangle v0.50
+PromiseKit mxcl/PromiseKit 6.16.3
 Moya Moya/Moya 15.0.0
 MonitorControl MonitorControl/MonitorControl v4.0.2
-ObjectMapper tristanhimmelman/ObjectMapper 3.5.3
-SkeletonView Juanpe/SkeletonView 1.26.0
+ObjectMapper tristanhimmelman/ObjectMapper 4.2.0
+SkeletonView Juanpe/SkeletonView 1.29.2
 firefox-ios mozilla-mobile/firefox-ios v39.0 0 6
 firefox-ios mozilla-mobile/firefox-ios v39.0 1 6
 firefox-ios mozilla-mobile/firefox-ios v39.0 2 6
 firefox-ios mozilla-mobile/firefox-ios v39.0 3 6
 firefox-ios mozilla-mobile/firefox-ios v39.0 4 6
 firefox-ios mozilla-mobile/firefox-ios v39.0 5 6
-AudioKit AudioKit/AudioKit 5.3.0
+AudioKit AudioKit/AudioKit 5.3.2
 Starscream daltoniam/Starscream 4.0.4
 MessageKit MessageKit/MessageKit 3.7.0
 KeychainAccess kishikawakatsumi/KeychainAccess v4.2.2
-Nuke kean/Nuke 10.6.1
+Nuke kean/Nuke 10.7.1
 Swinject Swinject/Swinject 2.8.1
-GRDB groue/GRDB.swift v5.17.0 0 2
-GRDB groue/GRDB.swift v5.17.0 1 2
+GRDB groue/GRDB.swift v5.19.0 0 2
+GRDB groue/GRDB.swift v5.19.0 1 2

--- a/scripts/update-top-repos.sh
+++ b/scripts/update-top-repos.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+
+set -e
+
+parser_dir="$(pwd)"
+
+. $parser_dir/scripts/common.sh
+
+function update() {
+    repo=$1
+    cd $tmpdir/$repo
+
+    git config remote.origin.fetch "+refs/heads/*:refs/remotes/origin/*"
+    git fetch origin --unshallow 2>/dev/null || git fetch origin
+    remote_head_commit=$(git ls-remote | grep HEAD | awk '{ print $1 }')
+    # Find the oldest branch that contains the remote HEAD commit, which will correspond to the remote HEAD branch (i.e.
+    # what's sometimes called `main` or `master`. Other branches may be newer than this one if they are a fast-forward
+    # of `main`, but it's not possible for an _older_ branch to have the commit unless it's literally equivalent. If it
+    # is equivalent, it doesn't matter.
+    remote_head_branch=$(git branch -r --contains $remote_head_commit --sort=-committerdate | tac | head -1)
+
+    # Figure out which branch the passed-in tag was tracking. We prefer the main branch, if possible, but can fall back
+    # to another if needed.
+    if git branch -r --contains HEAD | grep -q $remote_head_branch; then
+        # Our tag was on `main` (or equivalent), so use that branch directly.
+        branch=$remote_head_branch
+    else
+        # Our tag was not on `main`, so use the newest branch that it _was_ on.
+        branch=$(git branch -r --contains HEAD --sort=-committerdate | head -1)
+    fi
+
+    # Find the latest tag on this branch, and print it along with the other fields that we were given.
+    new_tag=$(git describe --tags $branch | sed 's/\(.*\)-.*-.*/\1/')
+    echo $1 $2 $new_tag $4 $5
+}
+
+while read line ; do
+    cd $tmpdir
+    checkout $line
+    update $line
+done < $top_repositories > $top_repositories.new
+
+mv $top_repositories.new $top_repositories
+
+# If the repository is now dirty, we have new versions available. Commit them and publish a PR.
+cd $parser_dir
+if ! git diff --quiet; then
+    git config --local user.email alex.pinkus@gmail.com
+    git config --local user.name "Alex Pinkus (Bot)"
+    git add ./script-data
+    git commit -m "Updating top repository version"
+    branch_name=repo-update-$(date +%Y-%m-%d)
+    git checkout -b $branch_name
+    echo "Creating pull request..."
+    gh auth setup-git
+    git remote add dest "https://$GITHUB_ACTOR:$GITHUB_TOKEN@github.com/$GITHUB_REPOSITORY.git"
+    git push dest HEAD:$branch_name
+    git fetch origin
+    gh pr create --fill --draft
+    echo "Pull request created!"
+else
+    echo "No repositories have been updated, so there's nothing more to do!"
+fi


### PR DESCRIPTION
Adds a script to automatically fetch the latest tag available for each
repository, so that we get alerted to any new code that can't be parsed.
This is intended to be run on a regular basis.

Also updates the top repositories to match the values that this script
finds.
