### PR TITLE
Tweak CI actions

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -35,8 +35,3 @@ jobs:
     - run: npm run test-ci
     - run: cargo test
     - run: cd ./test-npm-package && npm test; cd ..
-    - name: Publish parser source
-      uses: actions/upload-artifact@v2
-      with:
-        name: generated-parser-src
-        path: src

--- a/.github/workflows/parser-src.yml
+++ b/.github/workflows/parser-src.yml
@@ -1,0 +1,23 @@
+name: Publish `grammar.json` and `parser.c`
+
+on:
+  push:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Use Node.js
+      uses: actions/setup-node@v2
+      with:
+        node-version: 16.x
+        cache: 'npm'
+    - run: npm install
+    - run: npm run test-ci
+    - name: Publish parser source
+      uses: actions/upload-artifact@v2
+      with:
+        name: generated-parser-src
+        path: src

--- a/.github/workflows/top-repos.yml
+++ b/.github/workflows/top-repos.yml
@@ -63,7 +63,6 @@ jobs:
         node-version: '16.x'
         cache: 'npm'
     - run: npm install
-    - run: npm run test-ci
     - run: ./scripts/top-repos.sh ${{matrix.repo}}
   badge_gen:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -88,6 +88,6 @@ If you need a `parser.c`, and you don't care about the tree-sitter version, but 
 allow you to obtain the parser, you can just download one from a recent workflow run in this package. To do so:
 * Go to the [GitHub actions page](https://github.com/alex-pinkus/tree-sitter-swift/actions) for this
   repository.
-* Click on the "Check grammar and style" action for the appropriate commit.
+* Click on the "Publish `grammar.json` and `parser.c`" action for the appropriate commit.
 * Go down to `Artifacts` and click on `generated-parser-src`. All the relevant parser files will be available in your
   download.

--- a/scripts/update-top-repos.sh
+++ b/scripts/update-top-repos.sh
@@ -56,7 +56,7 @@ if ! git diff --quiet; then
     git remote add dest "https://$GITHUB_ACTOR:$GITHUB_TOKEN@github.com/$GITHUB_REPOSITORY.git"
     git push dest HEAD:$branch_name
     git fetch origin
-    gh pr create --fill --draft
+    gh pr create --fill
     echo "Pull request created!"
 else
     echo "No repositories have been updated, so there's nothing more to do!"


### PR DESCRIPTION
* Separate publish action (of grammar.json, etc) from check.yml
* Skip running `test-ci` when testing GitHub repos
* Don't publish repo updates as draft