### PR TITLE
Wait for tree-sitter to exist before generating

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -34,4 +34,5 @@ jobs:
       env:
           PREFIX: /tmp
     - run: cargo test
-    - run: cd ./test-npm-package && npm test; cd ..
+    - run: cd ./test-npm-package && npm test; cd -
+    - run: npm pack && cd .. && npm install -g ./tree-sitter-swift/tree-sitter-swift-*.tgz; cd -

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,9 +10,9 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@types/node": "^16.11.10",
         "nan": "^2.15.0",
-        "tree-sitter-cli": "^0.20.0"
+        "tree-sitter-cli": "^0.20.0",
+        "which": "2.0.2"
       },
       "devDependencies": {
         "node-gyp": "^8.4.1",
@@ -59,11 +59,6 @@
       "engines": {
         "node": ">= 6"
       }
-    },
-    "node_modules/@types/node": {
-      "version": "16.11.21",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.21.tgz",
-      "integrity": "sha512-Pf8M1XD9i1ksZEcCP8vuSNwooJ/bZapNmIzpmsMaL+jMI+8mEYU3PKvs+xDNuQcJWF/x24WzY4qxLtB0zNow9A=="
     },
     "node_modules/abbrev": {
       "version": "1.1.1",
@@ -474,8 +469,7 @@
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
-      "dev": true
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
     },
     "node_modules/lru-cache": {
       "version": "6.0.0",
@@ -558,7 +552,6 @@
       "integrity": "sha512-CGH1eblLq26Y15+Azk7ey4xh0J/XfJfrCox5LDJiKqI2Q2iwOLOKrlmIaODiSQS8d18jalF6y2K2ePUm0CmShw==",
       "dev": true,
       "dependencies": {
-        "encoding": "^0.1.12",
         "minipass": "^3.1.0",
         "minipass-sized": "^1.0.3",
         "minizlib": "^2.0.0"
@@ -1000,7 +993,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "dev": true,
       "dependencies": {
         "isexe": "^2.0.0"
       },
@@ -1065,11 +1057,6 @@
       "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
       "integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==",
       "dev": true
-    },
-    "@types/node": {
-      "version": "16.11.21",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.21.tgz",
-      "integrity": "sha512-Pf8M1XD9i1ksZEcCP8vuSNwooJ/bZapNmIzpmsMaL+jMI+8mEYU3PKvs+xDNuQcJWF/x24WzY4qxLtB0zNow9A=="
     },
     "abbrev": {
       "version": "1.1.1",
@@ -1409,8 +1396,7 @@
     "isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
-      "dev": true
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
     },
     "lru-cache": {
       "version": "6.0.0",
@@ -1801,7 +1787,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "dev": true,
       "requires": {
         "isexe": "^2.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A tree-sitter grammar for the Swift programming language.",
   "main": "bindings/node/index.js",
   "scripts": {
-    "install": "tree-sitter generate",
+    "install": "node scripts/wait-for-tree-sitter.js && tree-sitter generate",
     "postinstall": "node-gyp configure && node-gyp build",
     "ci": "prettier --check grammar.js",
     "test-ci": "./scripts/test-with-memcheck.sh --install-valgrind",
@@ -25,9 +25,9 @@
   },
   "homepage": "https://github.com/alex-pinkus/tree-sitter-swift#readme",
   "dependencies": {
-    "@types/node": "^16.11.10",
     "nan": "^2.15.0",
-    "tree-sitter-cli": "^0.20.0"
+    "tree-sitter-cli": "^0.20.0",
+    "which": "2.0.2"
   },
   "devDependencies": {
     "node-gyp": "^8.4.1",

--- a/scripts/wait-for-tree-sitter.js
+++ b/scripts/wait-for-tree-sitter.js
@@ -1,0 +1,77 @@
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
+const which = require("which");
+const { promisify } = require("util");
+const stat = promisify(fs.stat);
+
+async function main() {
+  const treeSitterExecutable = await which("tree-sitter");
+  if (!treeSitterExecutable.includes("node_modules")) {
+    // Not installed through npm, so should be safe.
+    return;
+  }
+
+  const realTreeSitterDir = path.join(
+    treeSitterExecutable,
+    "..",
+    "..",
+    "tree-sitter-cli"
+  );
+  let timeout = undefined;
+  let timeoutResolve = undefined;
+  Promise.race([
+    waitForOneOf(realTreeSitterDir, ["tree-sitter", "tree-sitter.exe"]).then(
+      () => {
+        clearTimeout(timeout);
+        timeoutResolve();
+      }
+    ),
+    new Promise((resolve) => {
+      timeoutResolve = resolve;
+      timeout = setTimeout(resolve, 10000);
+    }),
+  ]);
+}
+
+async function waitForOneOf(dir, files) {
+  for (const file of files) {
+    try {
+      if (await canExecute(path.join(dir, file))) {
+        return;
+      }
+    } catch {
+      // File doesn't yet exist -- we must wait for it.
+    }
+  }
+
+  await new Promise((resolve) => {
+    try {
+      fs.watch(dir, { persistent: false }, (eventType, filename) => {
+        if (
+          (eventType !== "rename" || os.platform() !== "win32") &&
+          files.includes(filename)
+        ) {
+          let resolved = false;
+          canExecute(path.join(dir, filename)).then((canExec) => {
+            if (canExec && !resolved) {
+              resolve();
+              resolved = true;
+            }
+          });
+        }
+      });
+    } catch (err) {
+      if (err.name !== "AbortError") {
+        console.error(err);
+      }
+    }
+  });
+}
+
+async function canExecute(filePath) {
+  const fileStat = await stat(filePath);
+  return fileStat.mode & 0111 || os.platform() === "win32";
+}
+
+main();


### PR DESCRIPTION
The `tree-sitter` command is not guaranteed to exist at the time that
its `install.js` terminates. It may still be downloading the appropriate
binary, or may not have marked it as executable.

To work around this, we update our install script to wait for the file
to be marked as executable before we run `tree-sitter generate`. This is
a workaround for the real issue and can be removed once the real issue
is fixed.

Fixes #119
