### PR TITLE
Use generic match predicate

### DIFF
--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -59,7 +59,7 @@
     (navigation_suffix (simple_identifier) @function)))
 ((navigation_expression
    (simple_identifier) @type) ; SomeType.method(): highlight SomeType as a type
-   (#lua-match? @type "^[A-Z]"))
+   (#match? @type "^[A-Z]"))
 
 (directive) @function.macro
 (diagnostic) @function.macro


### PR DESCRIPTION
I'm not certain why another parser might use `#lua-match?`, but `#match?` is more standard across the tree-sitter ecosystem, and is fairly well-supported by a number of highlighting bindings, including tree-sitter's own rust implementation.