### PR TITLE
Manually inline `_locally_permitted_modifiers`

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -214,6 +214,7 @@ module.exports = grammar({
     $._as_bang_custom,
     $._async_keyword_custom,
   ],
+  inline: ($) => [$._locally_permitted_modifiers],
   rules: {
     ////////////////////////////////
     // File Structure


### PR DESCRIPTION
See https://github.com/returntocorp/ocaml-tree-sitter-semgrep/issues/286

When generating a simplified grammar, the `ocaml-tree-sitter` code generator forces all hidden nodes to be visible. It appears that hidden nodes automatically get marked as `inline`, and that without that auto-inlining, the `_locally_permitted_modifiers` rule causes a conflict.

Rather than making the semgrep folks work around their conflict, we just check the `inline` declaration into the grammar itself so that it sticks around in the simplified grammar.
