### PR TITLE
highlight query update

### DIFF
--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -36,6 +36,7 @@
   "protocol"
   "extension"
   "indirect"
+  "some"
 ] @keyword
 
 [

--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -3,7 +3,6 @@
 
 ; Identifiers
 (attribute) @variable
-(simple_identifier) @variable
 (type_identifier) @type
 (self_expression) @variable.builtin
 


### PR DESCRIPTION
I found that the simple_identifier variable is too broad, it overlaps with many other patterns. I believe it's ok to remove it from the top level.