### PR TITLE
Add a field name for bound identifiers

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -1801,7 +1801,7 @@ function generate_pattern_matching_rule(
     : generate_case_pattern($, allows_binding);
   var expression_pattern = allows_expressions
     ? $._expression
-    : $.simple_identifier;
+    : field("bound_identifier", $.simple_identifier);
   var all_patterns = always_allowed_patterns
     .concat(binding_pattern_if_allowed)
     .concat(case_pattern)

--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -28,6 +28,7 @@
 (type_parameter (type_identifier) @parameter)
 (inheritance_constraint (identifier (simple_identifier) @parameter))
 (equality_constraint (identifier (simple_identifier) @parameter))
+(non_binding_pattern bound_identifier: (simple_identifier)) @variable
 
 [
   "typealias"


### PR DESCRIPTION
This makes obsolete the overly-broad `@variable` rule on
`simple_identifier`, while still marking bound variable names as
variables.
