### PR TITLE
Refactor availability_argument rule

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -1117,14 +1117,9 @@ module.exports = grammar({
         )
       ),
     availability_condition: ($) =>
-      seq(
-        "#available",
-        "(",
-        sep1(choice($._availability_argument, "*"), ","),
-        ")"
-      ),
+      seq("#available", "(", sep1($._availability_argument, ","), ")"),
     _availability_argument: ($) =>
-      seq($.identifier, sep1($.integer_literal, ".")),
+      choice(seq($.identifier, sep1($.integer_literal, ".")), "*"),
     ////////////////////////////////
     // Declarations - https://docs.swift.org/swift-book/ReferenceManual/Declarations.html
     ////////////////////////////////


### PR DESCRIPTION
This is a little different than the other changes I've made recently. It doesn't deduplicate anything in the grammar, but it still removes an anonymous node in the CST generated by ocaml-tree-sitter-semgrep. This is because ocaml-tree-sitter-semgrep chooses to inline the availability_condition rule into the `if_condition_sequence_item` rule. Because of this, it previously generated an anonymous type in the CST corresponding with the fragment that is now called `_availability_argument`.

Partially addresses #132