### PR TITLE
Factor out enum_entry_suffix rule

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -1437,16 +1437,16 @@ module.exports = grammar({
         sep1(
           seq(
             field("name", $.simple_identifier),
-            optional(
-              choice(
-                field("data_contents", $.enum_type_parameters),
-                seq($._equal_sign, field("raw_value", $._expression))
-              )
-            )
+            optional($._enum_entry_suffix)
           ),
           ","
         ),
         optional(";")
+      ),
+    _enum_entry_suffix: ($) =>
+      choice(
+        field("data_contents", $.enum_type_parameters),
+        seq($._equal_sign, field("raw_value", $._expression))
       ),
     enum_type_parameters: ($) =>
       seq(


### PR DESCRIPTION
Even though this does not appear at first to remove any duplication, this still removes an anonymous CST node that was previously generated by ocaml-tree-sitter-semgrep. This is because the `sep1` function duplicates its first argument in the resulting grammar.

Partially addresses #132