### PR TITLE
Standardized makefile and c bindings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ Cargo.lock
 *.so
 *.o
 bindings/c/*.h
+bindings/c/tree-sitter-*.pc

--- a/bindings/c/tree-sitter.pc.in
+++ b/bindings/c/tree-sitter.pc.in
@@ -5,7 +5,7 @@ additionallibs=@ADDITIONALLIBS@
 
 Name: tree-sitter-@PARSERNAME@
 Description: A tree-sitter grammar for the @PARSERNAME@ programming language.
-URL: @PARSERREPOURL@
+URL: @PARSERURL@
 Version: @VERSION@
 Libs: -L${libdir} ${additionallibs} -ltree-sitter-@PARSERNAME@
 Cflags: -I${includedir}


### PR DESCRIPTION
In https://github.com/alex-pinkus/tree-sitter-swift/pull/111 @krzyzanowskim added a Makefile and C bindings. These differed from the original "standard" version, but were better in many ways. I used this version as a template to fix up the existing Makefiles in other parsers, and in the process made just a few changes. I'm now moving those back here.

- Uses more built-in make functions
- Correctly assigns the parser URL in the pkgconfig file
- Treats the .pc file as a build artifact, just the .h
- Changes the header name from `tree_sitter/tree-sitter-swift.h` to `tree_sitter/swift.h`

The last one does have the potential to cause issues. But, it seems worth standardizing the header name to match other how other parsers do it.

I will coordinate a fix for https://github.com/krzyzanowskim/tree-sitter-xcframework, so I expect problems to be minimal.