### PR TITLE
[wip] allow for custom operators to end in '<'

### DIFF
--- a/corpus/functions.txt
+++ b/corpus/functions.txt
@@ -343,6 +343,27 @@ public prefix func ! (value: Wrapped<F>) -> Bool {
           (boolean_literal))))))
 
 ================================================================================
+'<' at the end of custom operator doesn't get confused for type arguments
+================================================================================
+
+infix operator <*< : MyPrecedence
+
+func <*<<<T>() {}
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (operator_declaration
+    (custom_operator)
+    (simple_identifier))
+  (function_declaration
+    (custom_operator)
+    (type_parameters
+      (type_parameter
+        (type_identifier)))
+    (function_body)))
+
+================================================================================
 Custom operators
 ================================================================================
 

--- a/grammar.js
+++ b/grammar.js
@@ -1367,7 +1367,6 @@ module.exports = grammar({
           "name",
           choice(
             $.simple_identifier,
-            $._referenceable_operator_without_custom,
             alias($.function_definition_operator, $.custom_operator),
             $._bitwise_binary_operator
           )

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -28,7 +28,8 @@ enum TokenType {
     AS_KEYWORD,
     AS_QUEST,
     AS_BANG,
-    ASYNC_KEYWORD
+    ASYNC_KEYWORD,
+    OPERATOR_LT
 };
 
 #define OPERATOR_COUNT 22
@@ -139,7 +140,6 @@ bool is_cross_semi_token(enum TokenType op) {
     case AS_BANG:
     case ASYNC_KEYWORD:
         return true;
-    case BANG:
     default:
         return false;
     }
@@ -398,7 +398,7 @@ static enum ParseDirective eat_whitespace(
 
     lexer->mark_end(lexer);
 
-    if (true && ws_directive == CONTINUE_PARSING_TOKEN_FOUND && lookahead == '/') {
+    if (ws_directive == CONTINUE_PARSING_TOKEN_FOUND && lookahead == '/') {
         bool has_seen_single_comment = false;
         while (lexer->lookahead == '/') {
             // It's possible that this is a comment - start an exploratory mission to find out, and if it is, look for what
@@ -601,6 +601,16 @@ bool tree_sitter_swift_external_scanner_scan(
         lexer->mark_end(lexer);
         lexer->result_symbol = comment_result;
         return true;
+    }
+
+    if (valid_symbols[OPERATOR_LT] && lexer->lookahead == '<') {
+      advance(lexer);
+      // Check that a type argument does not follow '<'
+      if (!isalpha(lexer->lookahead)) {
+        lexer->mark_end(lexer);
+        lexer->result_symbol = OPERATOR_LT;
+        return true;
+      }
     }
 
     // NOTE: this will consume any `#` characters it sees, even if it does not find a result. Keep


### PR DESCRIPTION
This is an incomplete PR to allow for custom operators to end with `<`. I intend to finish it later but I'm opening it right now for visibility's sake.

The main idea is to introduce an external `OPERATOR_LT` symbol only for the places where it needs to be disambiguated for type arguments - that is, to my knowledge, only in the function definition position. There might be more suitable places since I'm not very familiar with Swift.

While it passes for the new `'<' at the end of custom operator doesn't get confused for type arguments` test, it also currently breaks lots of existing tests and that should be fixed.