### PR TITLE
Fix incorrect parsing of binary expressions (fixes #153)

### DIFF
--- a/corpus/expressions.txt
+++ b/corpus/expressions.txt
@@ -70,6 +70,34 @@ a
     (simple_identifier)))
 
 ================================================================================
+Conjunction with call sites
+================================================================================
+
+a && b()
+
+a
+    && c.b()
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (conjunction_expression
+    (simple_identifier)
+    (call_expression
+          (simple_identifier)
+          (call_suffix
+            (value_arguments))))
+  (conjunction_expression
+    (simple_identifier)
+    (call_expression
+          (navigation_expression
+            (simple_identifier)
+            (navigation_suffix
+              (simple_identifier)))
+          (call_suffix
+            (value_arguments)))))
+
+================================================================================
 Bitwise operations
 ================================================================================
 

--- a/corpus/statements.txt
+++ b/corpus/statements.txt
@@ -686,6 +686,31 @@ else if bar {
       (simple_identifier))))
 
 ================================================================================
+If try
+================================================================================
+
+    if try limit == nil && singleResult && !expectsSingleResult {
+        return a
+    }
+
+--------------------------------------------------------------------------------
+
+(source_file
+      (if_statement
+        (conjunction_expression
+          (try_expression
+            (equality_expression
+              (simple_identifier)))
+          (conjunction_expression
+            (simple_identifier)
+            (prefix_expression
+              (bang)
+              (simple_identifier))))
+        (statements
+          (control_transfer_statement
+            (simple_identifier)))))
+
+================================================================================
 Guard statements
 ================================================================================
 


### PR DESCRIPTION
Should I apply this similar pattern for other binary operators too? Or is there a nicer way to do it :O ? 