### PR TITLE
Fix hang when the last line is a comment

### DIFF
--- a/corpus/comments.txt
+++ b/corpus/comments.txt
@@ -1,23 +1,25 @@
-==================
+================================================================================
 Comments
-==================
+================================================================================
 
 1 + 2
 // 1 + 2
 /* Hello world */
 /** I am a doc comment */
 
----
+--------------------------------------------------------------------------------
 
 (source_file
-    (additive_expression (integer_literal) (integer_literal))
-    (comment)
-    (multiline_comment)
-    (multiline_comment))
+  (additive_expression
+    (integer_literal)
+    (integer_literal))
+  (comment)
+  (multiline_comment)
+  (multiline_comment))
 
-==================
+================================================================================
 Nested Comments
-==================
+================================================================================
 
 /*
   This is how comments work: //
@@ -48,19 +50,22 @@ func doesExist() { }
   ****/
 ****/
 
----
-(source_file
-    (multiline_comment)
-    (multiline_comment)
-    (comment)
-    (multiline_comment)
-    (function_declaration (simple_identifier) (function_body))
-    (multiline_comment)
-    (multiline_comment))
+--------------------------------------------------------------------------------
 
-==================
+(source_file
+  (multiline_comment)
+  (multiline_comment)
+  (comment)
+  (multiline_comment)
+  (function_declaration
+    (simple_identifier)
+    (function_body))
+  (multiline_comment)
+  (multiline_comment))
+
+================================================================================
 Almost nested comments
-==================
+================================================================================
 
 /*
     This is allowed in a comment but does not nest: /
@@ -75,8 +80,24 @@ Almost nested comments
 */
 
 
----
+--------------------------------------------------------------------------------
+
 (source_file
-    (multiline_comment)
-    (multiline_comment)
-    (multiline_comment))
+  (multiline_comment)
+  (multiline_comment)
+  (multiline_comment))
+
+================================================================================
+Single line comment at the end of a non-empty file
+================================================================================
+
+class SwiftExamples {
+}
+// Some comment
+--------------------------------------------------------------------------------
+
+(source_file
+  (class_declaration
+    (type_identifier)
+    (class_body))
+  (comment))

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -421,7 +421,7 @@ static enum ParseDirective eat_whitespace(
                 // and eventually had a well-formed comment or an EOF. Thus, if we're currently looking at a `/`, it's
                 // the second one of those and it means we have a single-line comment.
                 has_seen_single_comment = true;
-                while (lexer->lookahead != '\n') {
+                while (lexer->lookahead != '\n' && lexer->lookahead != '\0') {
                     lexer->advance(lexer, true);
                 }
             } else if (iswspace(lexer->lookahead)) {


### PR DESCRIPTION
Fixes #159

This was the same problem as #146, where there was a `while` loop in the custom scanner that terminated on newlines but not on EOF. To fix, we just terminate on EOF for this loop as well.
