### PR TITLE
Parse files that end without a newline or semicolon

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -222,7 +222,13 @@ module.exports = grammar({
     source_file: ($) =>
       seq(
         optional($.shebang_line),
-        repeat(seq($._top_level_statement, $._semi))
+        optional(
+          seq(
+            $._top_level_statement,
+            repeat(seq($._semi, $._top_level_statement)),
+            optional($._semi)
+          )
+        )
       ),
     shebang_line: ($) => seq("#!", /[^\r\n]*/),
     ////////////////////////////////


### PR DESCRIPTION
See #166

Unfortunately, it doesn't look straightforward to include this example in the tests.

```
$ echo -n "print(3)" > nonewline.swift
$ npx tree-sitter parse nonewline.swift # No parse error
```