### PR TITLE
WIP: Simplify pattern rules

### DIFF
--- a/corpus/annotations.txt
+++ b/corpus/annotations.txt
@@ -1,28 +1,31 @@
-==================
+================================================================================
 Annotations
-==================
+================================================================================
 
 @Test
 class Empty { }
 
----
+--------------------------------------------------------------------------------
 
 (source_file
-    (class_declaration
-        (modifiers (attribute (user_type (type_identifier))))
-        (type_identifier)
-        (class_body)))
+  (class_declaration
+    (modifiers
+      (attribute
+        (user_type
+          (type_identifier))))
+    (type_identifier)
+    (class_body)))
 
-==================
+================================================================================
 Multiple annotations on a variable
-==================
+================================================================================
 
 class X {
  @A @B
  override let s: String
 }
 
----
+--------------------------------------------------------------------------------
 
 (source_file
   (class_declaration
@@ -30,23 +33,29 @@ class X {
     (class_body
       (property_declaration
         (modifiers
-             (attribute (user_type (type_identifier)))
-             (attribute (user_type (type_identifier)))
-             (member_modifier))
-        (value_binding_pattern (non_binding_pattern (simple_identifier)))
-        (type_annotation (user_type (type_identifier)))))))
+          (attribute
+            (user_type
+              (type_identifier)))
+          (attribute
+            (user_type
+              (type_identifier)))
+          (member_modifier))
+        (pattern
+          (simple_identifier))
+        (type_annotation
+          (user_type
+            (type_identifier)))))))
 
-
-==================
+================================================================================
 Multiple annotations on a function
-==================
+================================================================================
 
 class X {
  @A @B
  func s() -> String { }
 }
 
----
+--------------------------------------------------------------------------------
 
 (source_file
   (class_declaration
@@ -54,12 +63,13 @@ class X {
     (class_body
       (function_declaration
         (modifiers
-          (attribute (user_type (type_identifier)))
-          (attribute (user_type (type_identifier))))
+          (attribute
+            (user_type
+              (type_identifier)))
+          (attribute
+            (user_type
+              (type_identifier))))
         (simple_identifier)
-        (user_type (type_identifier))
-    (function_body)))))
-
-
-
-
+        (user_type
+          (type_identifier))
+        (function_body)))))

--- a/corpus/classes.txt
+++ b/corpus/classes.txt
@@ -117,18 +117,16 @@ internal open class Test {
       (property_declaration
         (modifiers
           (visibility_modifier))
-        (value_binding_pattern
-          (non_binding_pattern
-            (simple_identifier)))
+        (pattern
+          (simple_identifier))
         (type_annotation
           (user_type
             (type_identifier))))
       (property_declaration
         (modifiers
           (visibility_modifier))
-        (value_binding_pattern
-          (non_binding_pattern
-            (simple_identifier)))
+        (pattern
+          (simple_identifier))
         (type_annotation
           (user_type
             (type_identifier))))
@@ -400,17 +398,15 @@ class SomethingElse: ThingProvider {
     (type_identifier)
     (class_body
       (property_declaration
-        (value_binding_pattern
-          (non_binding_pattern
-            (simple_identifier)))
+        (pattern
+          (simple_identifier))
         (type_annotation
           (user_type
             (type_identifier)))
         (integer_literal))
       (property_declaration
-        (value_binding_pattern
-          (non_binding_pattern
-            (simple_identifier)))
+        (pattern
+          (simple_identifier))
         (type_annotation
           (optional_type
             (user_type
@@ -418,17 +414,15 @@ class SomethingElse: ThingProvider {
       (property_declaration
         (modifiers
           (property_behavior_modifier))
-        (value_binding_pattern
-          (non_binding_pattern
-            (simple_identifier)))
+        (pattern
+          (simple_identifier))
         (type_annotation
           (user_type
             (type_identifier)))
         (simple_identifier))
       (property_declaration
-        (value_binding_pattern
-          (non_binding_pattern
-            (simple_identifier)))
+        (pattern
+          (simple_identifier))
         (type_annotation
           (user_type
             (type_identifier)))
@@ -436,9 +430,8 @@ class SomethingElse: ThingProvider {
           (statements
             (simple_identifier))))
       (property_declaration
-        (value_binding_pattern
-          (non_binding_pattern
-            (simple_identifier)))
+        (pattern
+          (simple_identifier))
         (type_annotation
           (user_type
             (type_identifier)))
@@ -451,9 +444,8 @@ class SomethingElse: ThingProvider {
             (setter_specifier)
             (simple_identifier))))
       (property_declaration
-        (value_binding_pattern
-          (non_binding_pattern
-            (simple_identifier)))
+        (pattern
+          (simple_identifier))
         (type_annotation
           (user_type
             (type_identifier)))
@@ -477,18 +469,15 @@ class SomethingElse: ThingProvider {
         (type_identifier)))
     (class_body
       (property_declaration
-        (value_binding_pattern
-          (non_binding_pattern
-            (simple_identifier)))
+        (pattern
+          (simple_identifier))
         (type_annotation
           (user_type
             (type_identifier)))
         (computed_property
           (statements
             (guard_statement
-              (value_binding_pattern
-                (non_binding_pattern
-                  (simple_identifier)))
+              (simple_identifier)
               (simple_identifier)
               (else)
               (statements
@@ -499,9 +488,9 @@ class SomethingElse: ThingProvider {
             (control_transfer_statement
               (simple_identifier)))))
       (function_declaration
-          (modifiers
-            (property_modifier)
-            (member_modifier))
+        (modifiers
+          (property_modifier)
+          (member_modifier))
         (simple_identifier)
         (function_body)))))
 
@@ -522,16 +511,14 @@ class Alphabet {
     (type_identifier)
     (class_body
       (property_declaration
-        (value_binding_pattern
-          (non_binding_pattern
-            (simple_identifier)))
+        (pattern
+          (simple_identifier))
         (type_annotation
           (user_type
             (type_identifier)))
         (computed_property
           (computed_getter
-            (getter_specifier
-              (async))
+            (getter_specifier)
             (statements
               (integer_literal))))))))
 
@@ -549,9 +536,8 @@ class Cat { let noise: String = "meow"; let claws: String = "retractable" }
     (type_identifier)
     (class_body
       (property_declaration
-        (value_binding_pattern
-          (non_binding_pattern
-            (simple_identifier)))
+        (pattern
+          (simple_identifier))
         (type_annotation
           (user_type
             (type_identifier)))
@@ -561,18 +547,16 @@ class Cat { let noise: String = "meow"; let claws: String = "retractable" }
     (type_identifier)
     (class_body
       (property_declaration
-        (value_binding_pattern
-          (non_binding_pattern
-            (simple_identifier)))
+        (pattern
+          (simple_identifier))
         (type_annotation
           (user_type
             (type_identifier)))
         (line_string_literal
           (line_str_text)))
       (property_declaration
-        (value_binding_pattern
-          (non_binding_pattern
-            (simple_identifier)))
+        (pattern
+          (simple_identifier))
         (type_annotation
           (user_type
             (type_identifier)))
@@ -591,9 +575,8 @@ var propertyMap: NodePropertyMap & KeypathSearchable {
 
 (source_file
   (property_declaration
-    (value_binding_pattern
-      (non_binding_pattern
-        (simple_identifier)))
+    (pattern
+      (simple_identifier))
     (type_annotation
       (protocol_composition_type
         (user_type
@@ -624,9 +607,8 @@ struct Adder {
     (type_identifier)
     (class_body
       (property_declaration
-        (value_binding_pattern
-          (non_binding_pattern
-            (simple_identifier)))
+        (pattern
+          (simple_identifier))
         (type_annotation
           (user_type
             (type_identifier))))
@@ -696,9 +678,8 @@ protocol Wrapper {
     (type_identifier)
     (protocol_body
       (protocol_property_declaration
-        (value_binding_pattern
-          (non_binding_pattern
-            (simple_identifier)))
+        (pattern
+          (simple_identifier))
         (type_annotation
           (user_type
             (type_identifier)))
@@ -808,16 +789,14 @@ class Test {
     (type_identifier)
     (class_body
       (property_declaration
-        (value_binding_pattern
-          (non_binding_pattern
-            (simple_identifier)))
+        (pattern
+          (simple_identifier))
         (type_annotation
           (user_type
             (type_identifier))))
       (property_declaration
-        (value_binding_pattern
-          (non_binding_pattern
-            (simple_identifier)))
+        (pattern
+          (simple_identifier))
         (type_annotation
           (user_type
             (type_identifier))))
@@ -983,9 +962,8 @@ enum CStyle {
       (property_declaration
         (modifiers
           (property_modifier))
-        (value_binding_pattern
-          (non_binding_pattern
-            (simple_identifier)))
+        (pattern
+          (simple_identifier))
         (type_annotation
           (user_type
             (type_identifier)))
@@ -1088,17 +1066,15 @@ public extension Foo where T == (arg1: Arg1, arg2: Arg2) { }
       (property_declaration
         (modifiers
           (property_modifier))
-        (value_binding_pattern
-          (non_binding_pattern
-            (simple_identifier)))
+        (pattern
+          (simple_identifier))
         (line_string_literal
           (line_str_text)))
       (property_declaration
         (modifiers
           (property_modifier))
-        (value_binding_pattern
-          (non_binding_pattern
-            (simple_identifier)))
+        (pattern
+          (simple_identifier))
         (type_annotation
           (user_type
             (type_identifier)))
@@ -1196,9 +1172,8 @@ enum ComputeType {
             (simple_identifier)
             (line_string_literal
               (line_str_text))))
-        (value_binding_pattern
-          (non_binding_pattern
-            (simple_identifier)))
+        (pattern
+          (simple_identifier))
         (type_annotation
           (user_type
             (type_identifier))))
@@ -1248,9 +1223,8 @@ let result: HasGeneric<P1 & P2> = HasGeneric<P1 & P2>(t: "Hello")
 
 (source_file
   (property_declaration
-    (value_binding_pattern
-      (non_binding_pattern
-        (simple_identifier)))
+    (pattern
+      (simple_identifier))
     (type_annotation
       (user_type
         (type_identifier)
@@ -1347,9 +1321,8 @@ let result = greet("me") as P1 & P2
 
 (source_file
   (property_declaration
-    (value_binding_pattern
-      (non_binding_pattern
-        (simple_identifier)))
+    (pattern
+      (simple_identifier))
     (as_expression
       (call_expression
         (simple_identifier)
@@ -1393,18 +1366,16 @@ public final class Foo {
       (property_declaration
         (modifiers
           (visibility_modifier))
-        (value_binding_pattern
-          (non_binding_pattern
-            (simple_identifier)))
+        (pattern
+          (simple_identifier))
         (type_annotation
           (user_type
             (type_identifier))))
       (property_declaration
         (modifiers
           (visibility_modifier))
-        (value_binding_pattern
-          (non_binding_pattern
-            (simple_identifier)))
+        (pattern
+          (simple_identifier))
         (type_annotation
           (user_type
             (type_identifier)))
@@ -1438,9 +1409,8 @@ public var someVar: String {
   (property_declaration
     (modifiers
       (visibility_modifier))
-    (value_binding_pattern
-      (non_binding_pattern
-        (simple_identifier)))
+    (pattern
+      (simple_identifier))
     (type_annotation
       (user_type
         (type_identifier)))

--- a/corpus/emojis.txt
+++ b/corpus/emojis.txt
@@ -10,21 +10,18 @@ let ☁️☀️☁️ = "clouds and sun"
 
 (source_file
   (property_declaration
-    (value_binding_pattern
-      (non_binding_pattern
-        (simple_identifier)))
+    (pattern
+      (simple_identifier))
     (line_string_literal
       (line_str_text)))
   (property_declaration
-    (value_binding_pattern
-      (non_binding_pattern
-        (simple_identifier)))
+    (pattern
+      (simple_identifier))
     (line_string_literal
       (line_str_text)))
   (property_declaration
-    (value_binding_pattern
-      (non_binding_pattern
-        (simple_identifier)))
+    (pattern
+      (simple_identifier))
     (line_string_literal
       (line_str_text))))
 
@@ -87,9 +84,8 @@ let number4️⃣ = nummber2️⃣ + number2️⃣
 
 (source_file
   (property_declaration
-    (value_binding_pattern
-      (non_binding_pattern
-        (simple_identifier)))
+    (pattern
+      (simple_identifier))
     (additive_expression
       (simple_identifier)
       (simple_identifier))))

--- a/corpus/expressions.txt
+++ b/corpus/expressions.txt
@@ -84,18 +84,18 @@ a
   (conjunction_expression
     (simple_identifier)
     (call_expression
-          (simple_identifier)
-          (call_suffix
-            (value_arguments))))
+      (simple_identifier)
+      (call_suffix
+        (value_arguments))))
   (conjunction_expression
     (simple_identifier)
     (call_expression
-          (navigation_expression
-            (simple_identifier)
-            (navigation_suffix
-              (simple_identifier)))
-          (call_suffix
-            (value_arguments)))))
+      (navigation_expression
+        (simple_identifier)
+        (navigation_suffix
+          (simple_identifier)))
+      (call_suffix
+        (value_arguments)))))
 
 ================================================================================
 Bitwise operations
@@ -242,9 +242,8 @@ let e = array[...]
 
 (source_file
   (property_declaration
-    (value_binding_pattern
-      (non_binding_pattern
-        (simple_identifier)))
+    (pattern
+      (simple_identifier))
     (call_expression
       (simple_identifier)
       (call_suffix
@@ -261,9 +260,8 @@ let e = array[...]
               (integer_literal))))))
     (simple_identifier))
   (property_declaration
-    (value_binding_pattern
-      (non_binding_pattern
-        (simple_identifier)))
+    (pattern
+      (simple_identifier))
     (call_expression
       (simple_identifier)
       (call_suffix
@@ -272,9 +270,8 @@ let e = array[...]
             (simple_identifier)
             (simple_identifier))))))
   (property_declaration
-    (value_binding_pattern
-      (non_binding_pattern
-        (simple_identifier)))
+    (pattern
+      (simple_identifier))
     (call_expression
       (simple_identifier)
       (call_suffix
@@ -285,9 +282,8 @@ let e = array[...]
             (simple_identifier)
             (simple_identifier))))))
   (property_declaration
-    (value_binding_pattern
-      (non_binding_pattern
-        (simple_identifier)))
+    (pattern
+      (simple_identifier))
     (call_expression
       (simple_identifier)
       (call_suffix
@@ -322,14 +318,12 @@ _ = someCall()
 
 (source_file
   (property_declaration
-    (value_binding_pattern
-      (non_binding_pattern
-        (simple_identifier)))
+    (pattern
+      (simple_identifier))
     (integer_literal))
   (property_declaration
-    (value_binding_pattern
-      (non_binding_pattern
-        (simple_identifier)))
+    (pattern
+      (simple_identifier))
     (type_annotation
       (user_type
         (type_identifier)))
@@ -368,9 +362,8 @@ let a: SomeClass = .someInstance
 
 (source_file
   (property_declaration
-    (value_binding_pattern
-      (non_binding_pattern
-        (simple_identifier)))
+    (pattern
+      (simple_identifier))
     (type_annotation
       (user_type
         (type_identifier)))
@@ -394,9 +387,8 @@ func math() {
     (function_body
       (statements
         (property_declaration
-          (value_binding_pattern
-            (non_binding_pattern
-              (simple_identifier)))
+          (pattern
+            (simple_identifier))
           (type_annotation
             (tuple_type
               (tuple_type_item
@@ -463,9 +455,8 @@ var result2 = [String: [Complex<[String: Any]>]]()
 
 (source_file
   (property_declaration
-    (value_binding_pattern
-      (non_binding_pattern
-        (simple_identifier)))
+    (pattern
+      (simple_identifier))
     (constructor_expression
       (user_type
         (type_identifier)
@@ -475,9 +466,8 @@ var result2 = [String: [Complex<[String: Any]>]]()
       (constructor_suffix
         (value_arguments))))
   (property_declaration
-    (value_binding_pattern
-      (non_binding_pattern
-        (simple_identifier)))
+    (pattern
+      (simple_identifier))
     (constructor_expression
       (dictionary_type
         (user_type
@@ -521,9 +511,8 @@ modifyThis(&this)
           (type_identifier))))
     (function_body))
   (property_declaration
-    (value_binding_pattern
-      (non_binding_pattern
-        (simple_identifier)))
+    (pattern
+      (simple_identifier))
     (dictionary_literal))
   (call_expression
     (simple_identifier)
@@ -545,9 +534,8 @@ let setterSelector = #selector(setter: self.bar)
 
 (source_file
   (property_declaration
-    (value_binding_pattern
-      (non_binding_pattern
-        (simple_identifier)))
+    (pattern
+      (simple_identifier))
     (selector_expression
       (call_expression
         (navigation_expression
@@ -559,18 +547,16 @@ let setterSelector = #selector(setter: self.bar)
             (value_argument
               (simple_identifier)))))))
   (property_declaration
-    (value_binding_pattern
-      (non_binding_pattern
-        (simple_identifier)))
+    (pattern
+      (simple_identifier))
     (selector_expression
       (navigation_expression
         (self_expression)
         (navigation_suffix
           (simple_identifier)))))
   (property_declaration
-    (value_binding_pattern
-      (non_binding_pattern
-        (simple_identifier)))
+    (pattern
+      (simple_identifier))
     (selector_expression
       (navigation_expression
         (self_expression)
@@ -607,9 +593,8 @@ let result: MyEnumType = condition ? .someEnumCase : .someOtherEnum
 
 (source_file
   (property_declaration
-    (value_binding_pattern
-      (non_binding_pattern
-        (simple_identifier)))
+    (pattern
+      (simple_identifier))
     (ternary_expression
       (tuple_expression
         (equality_expression
@@ -619,9 +604,8 @@ let result: MyEnumType = condition ? .someEnumCase : .someOtherEnum
           (simple_identifier)))
       (array_literal)))
   (property_declaration
-    (value_binding_pattern
-      (non_binding_pattern
-        (simple_identifier)))
+    (pattern
+      (simple_identifier))
     (type_annotation
       (user_type
         (type_identifier)))
@@ -673,7 +657,8 @@ for i in 0 ..< something.count {
 
 (source_file
   (for_statement
-    (simple_identifier)
+    (pattern
+      (simple_identifier))
     (range_expression
       (integer_literal)
       (navigation_expression
@@ -780,18 +765,16 @@ let keyPathStringExpression = #keyPath(someProperty)
 
 (source_file
   (property_declaration
-    (value_binding_pattern
-      (non_binding_pattern
-        (simple_identifier)))
+    (pattern
+      (simple_identifier))
     (navigation_expression
       (key_path_expression
         (type_identifier))
       (navigation_suffix
         (simple_identifier))))
   (property_declaration
-    (value_binding_pattern
-      (non_binding_pattern
-        (simple_identifier)))
+    (pattern
+      (simple_identifier))
     (call_expression
       (simple_identifier)
       (call_suffix
@@ -839,9 +822,8 @@ let keyPathStringExpression = #keyPath(someProperty)
       (simple_identifier)
       (integer_literal)))
   (property_declaration
-    (value_binding_pattern
-      (non_binding_pattern
-        (simple_identifier)))
+    (pattern
+      (simple_identifier))
     (navigation_expression
       (navigation_expression
         (key_path_expression
@@ -851,9 +833,8 @@ let keyPathStringExpression = #keyPath(someProperty)
       (navigation_suffix
         (simple_identifier))))
   (property_declaration
-    (value_binding_pattern
-      (non_binding_pattern
-        (simple_identifier)))
+    (pattern
+      (simple_identifier))
     (key_path_string_expression
       (simple_identifier))))
 
@@ -978,9 +959,8 @@ let two = 2
 
 (source_file
   (property_declaration
-    (value_binding_pattern
-      (non_binding_pattern
-        (wildcard_pattern)))
+    (pattern
+      (wildcard_pattern))
     (multiplicative_expression
       (tuple_expression
         (additive_expression
@@ -988,9 +968,8 @@ let two = 2
           (integer_literal)))
       (integer_literal)))
   (property_declaration
-    (value_binding_pattern
-      (non_binding_pattern
-        (simple_identifier)))
+    (pattern
+      (simple_identifier))
     (equality_expression
       (tuple_expression
         (additive_expression
@@ -998,9 +977,8 @@ let two = 2
           (integer_literal)))
       (integer_literal)))
   (property_declaration
-    (value_binding_pattern
-      (non_binding_pattern
-        (simple_identifier)))
+    (pattern
+      (simple_identifier))
     (additive_expression
       (additive_expression
         (integer_literal)
@@ -1108,7 +1086,8 @@ for try await value in values {
 
 (source_file
   (for_statement
-    (simple_identifier)
+    (pattern
+      (simple_identifier))
     (simple_identifier)
     (statements
       (call_expression
@@ -1131,9 +1110,8 @@ let a = false
 
 (source_file
   (property_declaration
-    (value_binding_pattern
-      (non_binding_pattern
-        (simple_identifier)))
+    (pattern
+      (simple_identifier))
     (boolean_literal))
   (simple_identifier))
 

--- a/corpus/functions.txt
+++ b/corpus/functions.txt
@@ -383,9 +383,8 @@ let messageCoerced = error ??? "nil"
 
 (source_file
   (property_declaration
-    (value_binding_pattern
-      (non_binding_pattern
-        (simple_identifier)))
+    (pattern
+      (simple_identifier))
     (infix_expression
       (simple_identifier)
       (custom_operator)
@@ -440,7 +439,6 @@ func maybe()
 (source_file
   (function_declaration
     (simple_identifier)
-    (async)
     (user_type
       (type_identifier))
     (function_body
@@ -450,7 +448,6 @@ func maybe()
             (integer_literal))))))
   (function_declaration
     (simple_identifier)
-    (async)
     (throws)
     (user_type
       (type_identifier))
@@ -722,9 +719,8 @@ private lazy var onCatClosure: (_ cat: Cat) throws -> Void = { _ in
     (modifiers
       (visibility_modifier)
       (property_behavior_modifier))
-    (value_binding_pattern
-      (non_binding_pattern
-        (simple_identifier)))
+    (pattern
+      (simple_identifier))
     (type_annotation
       (function_type
         (tuple_type

--- a/corpus/literals.txt
+++ b/corpus/literals.txt
@@ -168,17 +168,15 @@ let numerals = [1: "I", 4: "IV", 5: "V", 10: "X"]
 
 (source_file
   (property_declaration
-    (value_binding_pattern
-      (non_binding_pattern
-        (simple_identifier)))
+    (pattern
+      (simple_identifier))
     (array_literal
       (integer_literal)
       (integer_literal)
       (integer_literal)))
   (property_declaration
-    (value_binding_pattern
-      (non_binding_pattern
-        (simple_identifier)))
+    (pattern
+      (simple_identifier))
     (dictionary_literal
       (integer_literal)
       (line_string_literal
@@ -237,9 +235,8 @@ let _ = nil
 
 (source_file
   (property_declaration
-    (value_binding_pattern
-      (non_binding_pattern
-        (wildcard_pattern)))))
+    (pattern
+      (wildcard_pattern))))
 
 ================================================================================
 Raw strings
@@ -252,15 +249,13 @@ let _ = ##"Hello, so-called "world"!"##
 
 (source_file
   (property_declaration
-    (value_binding_pattern
-      (non_binding_pattern
-        (wildcard_pattern)))
+    (pattern
+      (wildcard_pattern))
     (raw_string_literal
       (raw_str_end_part)))
   (property_declaration
-    (value_binding_pattern
-      (non_binding_pattern
-        (wildcard_pattern)))
+    (pattern
+      (wildcard_pattern))
     (raw_string_literal
       (raw_str_end_part))))
 
@@ -270,13 +265,12 @@ Doesn't hang for incomplete raw strings (issue #146)
 
 let _ = #"Foo"
 
----
+--------------------------------------------------------------------------------
 
 (source_file
   (property_declaration
-    (value_binding_pattern
-      (non_binding_pattern
-        (wildcard_pattern)))
+    (pattern
+      (wildcard_pattern))
     (ERROR
       (UNEXPECTED '"'))
     (line_string_literal
@@ -351,9 +345,8 @@ let _ = ##"\##(a)\#(b)\##(c)\#(d)"# ##"##
               (multiline_comment))
             (raw_str_end_part))))))
   (property_declaration
-    (value_binding_pattern
-      (non_binding_pattern
-        (wildcard_pattern)))
+    (pattern
+      (wildcard_pattern))
     (raw_string_literal
       (raw_str_part)
       (raw_str_interpolation
@@ -362,15 +355,13 @@ let _ = ##"\##(a)\#(b)\##(c)\#(d)"# ##"##
           (simple_identifier)))
       (raw_str_end_part)))
   (property_declaration
-    (value_binding_pattern
-      (non_binding_pattern
-        (wildcard_pattern)))
+    (pattern
+      (wildcard_pattern))
     (raw_string_literal
       (raw_str_end_part)))
   (property_declaration
-    (value_binding_pattern
-      (non_binding_pattern
-        (wildcard_pattern)))
+    (pattern
+      (wildcard_pattern))
     (raw_string_literal
       (raw_str_part)
       (raw_str_interpolation
@@ -396,22 +387,19 @@ let infinity = "\u{221E}"
 
 (source_file
   (property_declaration
-    (value_binding_pattern
-      (non_binding_pattern
-        (simple_identifier)))
+    (pattern
+      (simple_identifier))
     (line_string_literal
       (str_escaped_char)))
   (property_declaration
-    (value_binding_pattern
-      (non_binding_pattern
-        (simple_identifier)))
+    (pattern
+      (simple_identifier))
     (line_string_literal
       (line_str_text)
       (str_escaped_char)))
   (property_declaration
-    (value_binding_pattern
-      (non_binding_pattern
-        (simple_identifier)))
+    (pattern
+      (simple_identifier))
     (line_string_literal
       (str_escaped_char))))
 
@@ -425,9 +413,8 @@ let playgroundLiteral = #imageLiteral(resourceName: "heart")
 
 (source_file
   (property_declaration
-    (value_binding_pattern
-      (non_binding_pattern
-        (simple_identifier)))
+    (pattern
+      (simple_identifier))
     (simple_identifier)
     (line_string_literal
       (line_str_text))))

--- a/corpus/statements.txt
+++ b/corpus/statements.txt
@@ -10,24 +10,21 @@ let `default` = 0
 
 (source_file
   (property_declaration
-    (value_binding_pattern
-      (non_binding_pattern
-        (simple_identifier)))
+    (pattern
+      (simple_identifier))
     (integer_literal))
   (property_declaration
-    (value_binding_pattern
-      (non_binding_pattern
-        (non_binding_pattern
-          (simple_identifier))
-        (non_binding_pattern
-          (simple_identifier))))
+    (pattern
+      (pattern
+        (simple_identifier))
+      (pattern
+        (simple_identifier)))
     (tuple_expression
       (integer_literal)
       (integer_literal)))
   (property_declaration
-    (value_binding_pattern
-      (non_binding_pattern
-        (simple_identifier)))
+    (pattern
+      (simple_identifier))
     (integer_literal)))
 
 ================================================================================
@@ -40,21 +37,17 @@ var one = 1, two = 2, four = 4, eight = 8
 
 (source_file
   (property_declaration
-    (value_binding_pattern
-      (non_binding_pattern
-        (simple_identifier)))
+    (pattern
+      (simple_identifier))
     (integer_literal)
-    (value_binding_pattern
-      (non_binding_pattern
-        (simple_identifier)))
+    (pattern
+      (simple_identifier))
     (integer_literal)
-    (value_binding_pattern
-      (non_binding_pattern
-        (simple_identifier)))
+    (pattern
+      (simple_identifier))
     (integer_literal)
-    (value_binding_pattern
-      (non_binding_pattern
-        (simple_identifier)))
+    (pattern
+      (simple_identifier))
     (integer_literal)))
 
 ================================================================================
@@ -77,7 +70,8 @@ for var value in values where value.isExcellent() {
 
 (source_file
   (for_statement
-    (simple_identifier)
+    (pattern
+      (simple_identifier))
     (type_annotation
       (user_type
         (type_identifier)))
@@ -90,19 +84,26 @@ for var value in values where value.isExcellent() {
             (value_argument
               (simple_identifier)))))))
   (for_statement
-    (simple_identifier)
-    (simple_identifier)
+    (pattern
+      (simple_identifier)
+      (pattern
+        (simple_identifier)))
     (simple_identifier))
   (for_statement
-    (simple_identifier)
-    (simple_identifier)
-    (integer_literal)
-    (simple_identifier)
-    (integer_literal)
+    (pattern
+      (simple_identifier)
+      (pattern
+        (pattern
+          (simple_identifier)
+          (pattern
+            (integer_literal)))
+        (pattern
+          (simple_identifier)
+          (pattern
+            (integer_literal)))))
     (simple_identifier))
   (for_statement
-    (binding_pattern_kind)
-    (non_binding_pattern
+    (pattern
       (simple_identifier))
     (simple_identifier)
     (where_clause
@@ -138,28 +139,28 @@ outerLoop: for outerObject in dataArray {
 
 (source_file
   (for_statement
-    (binding_pattern_kind)
-    (non_binding_pattern
-      (non_binding_pattern
+    (pattern
+      (pattern
         (simple_identifier))
       (user_type
         (type_identifier)))
     (simple_identifier))
   (for_statement
-    (binding_pattern_kind)
-    (non_binding_pattern
-      (non_binding_pattern
+    (pattern
+      (pattern
         (simple_identifier))
-      (non_binding_pattern
+      (pattern
         (simple_identifier)))
     (simple_identifier))
   (statement_label)
   (for_statement
-    (simple_identifier)
+    (pattern
+      (simple_identifier))
     (simple_identifier)
     (statements
       (for_statement
-        (simple_identifier)
+        (pattern
+          (simple_identifier))
         (simple_identifier)
         (statements
           (if_statement
@@ -205,10 +206,9 @@ repeat {
       (integer_literal))
     (comment))
   (while_statement
-    (value_binding_pattern
-      (non_binding_pattern
-        (simple_identifier)
-        (simple_identifier)))
+    (simple_identifier)
+    (pattern
+      (simple_identifier))
     (call_expression
       (simple_identifier)
       (call_suffix
@@ -239,22 +239,25 @@ switch something {
     (simple_identifier)
     (switch_entry
       (switch_pattern
-        (simple_identifier))
+        (pattern
+          (simple_identifier)))
       (statements
         (control_transfer_statement
           (line_string_literal
             (line_str_text)))))
     (switch_entry
       (switch_pattern
-        (simple_identifier))
+        (pattern
+          (simple_identifier)))
       (statements
         (control_transfer_statement
           (line_string_literal
             (line_str_text)))))
     (switch_entry
       (switch_pattern
-        (line_string_literal
-          (line_str_text)))
+        (pattern
+          (line_string_literal
+            (line_str_text))))
       (statements
         (control_transfer_statement
           (line_string_literal
@@ -290,20 +293,23 @@ case let .isExecutable(path?):
     (simple_identifier)
     (switch_entry
       (switch_pattern
-        (binding_pattern_kind)
-        (non_binding_pattern
+        (pattern
           (simple_identifier)
-          (wildcard_pattern)
-          (simple_identifier)))
+          (pattern
+            (wildcard_pattern))
+          (pattern
+            (simple_identifier))))
       (statements
         (simple_identifier)))
     (switch_entry
       (switch_pattern
-        (simple_identifier))
+        (pattern
+          (simple_identifier)))
       (where_keyword)
       (simple_identifier)
       (switch_pattern
-        (simple_identifier))
+        (pattern
+          (simple_identifier)))
       (statements
         (simple_identifier)))
     (switch_entry
@@ -320,10 +326,10 @@ case let .isExecutable(path?):
     (self_expression)
     (switch_entry
       (switch_pattern
-        (simple_identifier)
-        (binding_pattern_kind)
-        (non_binding_pattern
-          (simple_identifier)))
+        (pattern
+          (simple_identifier)
+          (pattern
+            (simple_identifier))))
       (statements
         (control_transfer_statement
           (line_string_literal
@@ -332,16 +338,41 @@ case let .isExecutable(path?):
               (simple_identifier))))))
     (switch_entry
       (switch_pattern
-        (binding_pattern_kind)
-        (non_binding_pattern
+        (pattern
           (simple_identifier)
-          (simple_identifier)))
+          (pattern
+            (simple_identifier))))
       (statements
         (control_transfer_statement
           (line_string_literal
             (line_str_text)
             (interpolated_expression
               (simple_identifier))))))))
+
+================================================================================
+Switch with extra parentheses
+================================================================================
+
+switch result {
+case let .success((successfulResult)):
+    return successfulResult
+}
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (switch_statement
+    (simple_identifier)
+    (switch_entry
+      (switch_pattern
+        (pattern
+          (simple_identifier)
+          (pattern
+            (pattern
+              (simple_identifier)))))
+      (statements
+        (control_transfer_statement
+          (simple_identifier))))))
 
 ================================================================================
 Imports
@@ -395,32 +426,27 @@ do {
   (do_statement
     (statements
       (property_declaration
-        (value_binding_pattern
-          (non_binding_pattern
-            (simple_identifier)))
+        (pattern
+          (simple_identifier))
         (integer_literal)))
     (catch_block
       (catch_keyword)
-      (binding_pattern
-        (binding_pattern
-          (binding_pattern_kind)
-          (non_binding_pattern
-            (simple_identifier)))
+      (pattern
+        (pattern
+          (simple_identifier))
         (user_type
           (type_identifier))))
     (catch_block
       (catch_keyword)
-      (binding_pattern
+      (pattern
         (user_type
           (type_identifier))
         (simple_identifier)))
     (catch_block
       (catch_keyword)
-      (binding_pattern
-        (binding_pattern
-          (binding_pattern_kind)
-          (non_binding_pattern
-            (simple_identifier)))
+      (pattern
+        (pattern
+          (simple_identifier))
         (user_type
           (type_identifier)))
       (where_clause
@@ -433,31 +459,28 @@ do {
           (integer_literal))))
     (catch_block
       (catch_keyword)
-      (binding_pattern
-        (binding_pattern_kind)
-        (non_binding_pattern
-          (user_type
-            (type_identifier))
-          (simple_identifier)
+      (pattern
+        (user_type
+          (type_identifier))
+        (simple_identifier)
+        (pattern
           (simple_identifier))))
     (catch_block
       (catch_keyword)
-      (binding_pattern
+      (pattern
         (user_type
           (type_identifier))
         (simple_identifier)
         (simple_identifier)
-        (binding_pattern_kind)
-        (non_binding_pattern
+        (pattern
           (simple_identifier))))
     (catch_block
       (catch_keyword)))
   (do_statement
     (statements
       (property_declaration
-        (value_binding_pattern
-          (non_binding_pattern
-            (simple_identifier)))
+        (pattern
+          (simple_identifier))
         (integer_literal)))))
 
 ================================================================================
@@ -481,9 +504,7 @@ someLabel: if a.isEmpty, let b = getB() {
 
 (source_file
   (if_statement
-    (value_binding_pattern
-      (non_binding_pattern
-        (simple_identifier)))
+    (simple_identifier)
     (call_expression
       (simple_identifier)
       (call_suffix
@@ -494,17 +515,15 @@ someLabel: if a.isEmpty, let b = getB() {
         (call_suffix
           (value_arguments)))))
   (if_statement
-    (binding_pattern
-      (simple_identifier)
+    (simple_identifier)
+    (pattern
       (wildcard_pattern))
     (call_expression
       (simple_identifier)
       (call_suffix
         (value_arguments))))
   (if_statement
-    (value_binding_pattern
-      (non_binding_pattern
-        (simple_identifier)))
+    (simple_identifier)
     (type_annotation
       (user_type
         (type_identifier)))
@@ -518,9 +537,7 @@ someLabel: if a.isEmpty, let b = getB() {
       (simple_identifier)
       (navigation_suffix
         (simple_identifier)))
-    (value_binding_pattern
-      (non_binding_pattern
-        (simple_identifier)))
+    (simple_identifier)
     (call_expression
       (simple_identifier)
       (call_suffix
@@ -545,9 +562,7 @@ func doSomething() {
     (function_body
       (statements
         (if_statement
-          (value_binding_pattern
-            (non_binding_pattern
-              (simple_identifier)))
+          (simple_identifier)
           (try_expression
             (call_expression
               (navigation_expression
@@ -581,9 +596,7 @@ if let something = doThing(), let somethingElse = something.somethingElse() {
 
 (source_file
   (if_statement
-    (value_binding_pattern
-      (non_binding_pattern
-        (simple_identifier)))
+    (simple_identifier)
     (call_expression
       (simple_identifier)
       (call_suffix
@@ -601,16 +614,12 @@ if let something = doThing(), let somethingElse = something.somethingElse() {
         (call_suffix
           (value_arguments)))))
   (if_statement
-    (value_binding_pattern
-      (non_binding_pattern
-        (simple_identifier)))
+    (simple_identifier)
     (call_expression
       (simple_identifier)
       (call_suffix
         (value_arguments)))
-    (value_binding_pattern
-      (non_binding_pattern
-        (simple_identifier)))
+    (simple_identifier)
     (call_expression
       (navigation_expression
         (simple_identifier)
@@ -637,15 +646,11 @@ else if let cPrime = c {
 
 (source_file
   (if_statement
-    (value_binding_pattern
-      (non_binding_pattern
-        (simple_identifier)))
+    (simple_identifier)
     (simple_identifier)
     (else)
     (if_statement
-      (value_binding_pattern
-        (non_binding_pattern
-          (simple_identifier)))
+      (simple_identifier)
       (simple_identifier)))
   (if_statement
     (equality_expression
@@ -653,9 +658,7 @@ else if let cPrime = c {
       (simple_identifier))
     (else)
     (if_statement
-      (value_binding_pattern
-        (non_binding_pattern
-          (simple_identifier)))
+      (simple_identifier)
       (simple_identifier))))
 
 ================================================================================
@@ -696,19 +699,19 @@ If try
 --------------------------------------------------------------------------------
 
 (source_file
-      (if_statement
-        (conjunction_expression
-          (try_expression
-            (equality_expression
-              (simple_identifier)))
-          (conjunction_expression
-            (simple_identifier)
-            (prefix_expression
-              (bang)
-              (simple_identifier))))
-        (statements
-          (control_transfer_statement
-            (simple_identifier)))))
+  (if_statement
+    (conjunction_expression
+      (try_expression
+        (equality_expression
+          (simple_identifier)))
+      (conjunction_expression
+        (simple_identifier)
+        (prefix_expression
+          (bang)
+          (simple_identifier))))
+    (statements
+      (control_transfer_statement
+        (simple_identifier)))))
 
 ================================================================================
 Guard statements
@@ -731,9 +734,7 @@ guard case justIdentifier = bound else { }
 
 (source_file
   (guard_statement
-    (value_binding_pattern
-      (non_binding_pattern
-        (simple_identifier)))
+    (simple_identifier)
     (call_expression
       (simple_identifier)
       (call_suffix
@@ -756,20 +757,17 @@ guard case justIdentifier = bound else { }
         (call_suffix
           (value_arguments)))))
   (guard_statement
-    (binding_pattern
-      (simple_identifier)
-      (simple_identifier)
-      (binding_pattern_kind)
-      (non_binding_pattern
-        (simple_identifier)))
+    (simple_identifier)
+    (simple_identifier)
+    (pattern
+      (simple_identifier))
     (call_expression
       (simple_identifier)
       (call_suffix
         (value_arguments)))
     (else))
   (guard_statement
-    (binding_pattern
-      (simple_identifier))
+    (simple_identifier)
     (simple_identifier)
     (else)))
 
@@ -785,9 +783,7 @@ guard let something = doThing(), something.isSpecial() else {
 
 (source_file
   (guard_statement
-    (value_binding_pattern
-      (non_binding_pattern
-        (simple_identifier)))
+    (simple_identifier)
     (call_expression
       (simple_identifier)
       (call_suffix
@@ -818,10 +814,7 @@ guard case let size: Int = variable.size else {
 
 (source_file
   (guard_statement
-    (binding_pattern
-      (binding_pattern_kind)
-      (non_binding_pattern
-        (simple_identifier)))
+    (simple_identifier)
     (type_annotation
       (user_type
         (type_identifier)))
@@ -886,9 +879,8 @@ let ø = unicode()
 
 (source_file
   (property_declaration
-    (value_binding_pattern
-      (non_binding_pattern
-        (simple_identifier)))
+    (pattern
+      (simple_identifier))
     (call_expression
       (simple_identifier)
       (call_suffix
@@ -927,9 +919,8 @@ public init() {
         (comment)
         (property_declaration
           (ownership_modifier)
-          (value_binding_pattern
-            (non_binding_pattern
-              (simple_identifier)))
+          (pattern
+            (simple_identifier))
           (simple_identifier))
         (class_declaration
           (inheritance_modifier)
@@ -977,12 +968,10 @@ async let bar = 66
 
 (source_file
   (property_declaration
-    (value_binding_pattern
-      (non_binding_pattern
-        (simple_identifier)))
+    (pattern
+      (simple_identifier))
     (integer_literal))
   (property_declaration
-    (value_binding_pattern
-      (non_binding_pattern
-        (simple_identifier)))
+    (pattern
+      (simple_identifier))
     (integer_literal)))

--- a/corpus/types.txt
+++ b/corpus/types.txt
@@ -202,9 +202,8 @@ let c: (third: C, fourth: D)
       (user_type
         (type_identifier))))
   (property_declaration
-    (value_binding_pattern
-      (non_binding_pattern
-        (simple_identifier)))
+    (pattern
+      (simple_identifier))
     (type_annotation
       (tuple_type
         (tuple_type_item
@@ -228,9 +227,8 @@ private var dictionary: [String: Any?]?
   (property_declaration
     (modifiers
       (visibility_modifier))
-    (value_binding_pattern
-      (non_binding_pattern
-        (simple_identifier)))
+    (pattern
+      (simple_identifier))
     (type_annotation
       (optional_type
         (dictionary_type
@@ -252,9 +250,8 @@ private var dictionary: [String: Any?]!
   (property_declaration
     (modifiers
       (visibility_modifier))
-    (value_binding_pattern
-      (non_binding_pattern
-        (simple_identifier)))
+    (pattern
+      (simple_identifier))
     (type_annotation
       (dictionary_type
         (user_type

--- a/grammar.js
+++ b/grammar.js
@@ -155,6 +155,11 @@ module.exports = grammar({
     // The `class` modifier is legal in many of the same positions that a class declaration itself would be.
     [$._bodyless_function_declaration, $.property_modifier],
     [$._local_class_declaration, $.modifiers],
+    // Patterns, man
+    [$._navigable_type_expression, $._case_pattern],
+    [$._no_expr_pattern_already_bound, $._binding_pattern_with_expr],
+    [$._no_expr_pattern_already_bound, $._expression],
+    [$._no_expr_pattern_already_bound, $._binding_pattern_no_expr],
   ],
   extras: ($) => [
     $.comment,
@@ -948,16 +953,13 @@ module.exports = grammar({
         $.statements,
         optional("fallthrough")
       ),
-    switch_pattern: ($) => generate_pattern_matching_rule($, true, false, true),
+    switch_pattern: ($) => alias($._binding_pattern_with_expr, $.pattern),
     do_statement: ($) =>
       prec.right(PRECS["do"], seq("do", $._block, repeat($.catch_block))),
     catch_block: ($) =>
       seq(
         $.catch_keyword,
-        field(
-          "error",
-          optional(generate_pattern_matching_rule($, true, false))
-        ),
+        field("error", optional(alias($._binding_pattern_no_expr, $.pattern))),
         optional($.where_clause),
         $._block
       ),
@@ -1075,7 +1077,7 @@ module.exports = grammar({
           "for",
           optional($._try_operator),
           optional($._await_operator),
-          field("item", generate_pattern_matching_rule($, true, true, false)),
+          field("item", alias($._binding_pattern_no_expr, $.pattern)),
           optional($.type_annotation),
           "in",
           field("collection", $._expression),
@@ -1213,7 +1215,7 @@ module.exports = grammar({
       prec.right(
         seq(
           optional($.modifiers),
-          field("name", $.value_binding_pattern),
+          field("name", alias($._binding_kind_and_pattern, $.pattern)),
           optional($.type_annotation),
           optional($.type_constraints),
           $.protocol_property_requirements
@@ -1226,13 +1228,10 @@ module.exports = grammar({
     _modifierless_property_declaration: ($) =>
       prec.right(
         seq(
-          choice(seq(optional($._async_modifier), "let"), "var"),
+          $._possibly_async_binding_pattern_kind,
           sep1(
             seq(
-              field(
-                "name",
-                alias($.property_binding_pattern, $.value_binding_pattern)
-              ),
+              field("name", alias($._no_expr_pattern_already_bound, $.pattern)),
               optional($.type_annotation),
               optional($.type_constraints),
               optional(
@@ -1246,8 +1245,6 @@ module.exports = grammar({
           )
         )
       ),
-    property_binding_pattern: ($) =>
-      generate_pattern_matching_rule($, false, false),
     typealias_declaration: ($) =>
       seq(optional($.modifiers), $._modifierless_typealias_declaration),
     _modifierless_typealias_declaration: ($) =>
@@ -1428,12 +1425,7 @@ module.exports = grammar({
     _as: ($) => alias($._as_custom, "as"),
     _as_quest: ($) => alias($._as_quest_custom, "as?"),
     _as_bang: ($) => alias($._as_bang_custom, "as!"),
-    _async_keyword: function ($) {
-      // Backward compatibility: make `async` both a named node and a string node. Remove this once downstream queries
-      // have all been switched over.
-      return prec(-1, alias($._async_keyword_internal, $.async));
-    },
-    _async_keyword_internal: ($) => alias($._async_keyword_custom, "async"),
+    _async_keyword: ($) => alias($._async_keyword_custom, "async"),
     _async_modifier: ($) => token("async"),
     throws: ($) => choice($._throws_keyword, $._rethrows_keyword),
     enum_class_body: ($) =>
@@ -1615,41 +1607,88 @@ module.exports = grammar({
     ////////////////////////////////
     // Patterns - https://docs.swift.org/swift-book/ReferenceManual/Patterns.html
     ////////////////////////////////
-    // Higher-than-default precedence to resolve `x as SomeType` ambiguity (expression patterns seem not to support
-    // as-expressions)
-    binding_pattern: ($) =>
-      prec.left(1, generate_pattern_matching_rule($, true, false, false, true)),
-    non_binding_pattern: ($) =>
-      prec.left(
-        1,
-        generate_pattern_matching_rule($, false, false, false, true)
+    _universally_allowed_pattern: ($) =>
+      choice(
+        $.wildcard_pattern,
+        $._tuple_pattern,
+        $._type_casting_pattern,
+        $._case_pattern
       ),
-    // Higher precedence than pattern w/o binding since these are strictly more flexible
+    _bound_identifier: ($) => field("bound_identifier", $.simple_identifier),
+
+    _binding_pattern_no_expr: ($) =>
+      seq(
+        choice(
+          $._universally_allowed_pattern,
+          $._binding_pattern,
+          $._bound_identifier
+        ),
+        optional($._quest)
+      ),
+    _no_expr_pattern_already_bound: ($) =>
+      seq(
+        choice($._universally_allowed_pattern, $._bound_identifier),
+        optional($._quest)
+      ),
     _binding_pattern_with_expr: ($) =>
-      prec.left(2, generate_pattern_matching_rule($, true, false, true, true)),
+      seq(
+        choice(
+          $._universally_allowed_pattern,
+          $._binding_pattern,
+          $._expression
+        ),
+        optional($._quest)
+      ),
     _non_binding_pattern_with_expr: ($) =>
-      prec.left(2, generate_pattern_matching_rule($, false, false, true, true)),
+      seq(
+        choice($._universally_allowed_pattern, $._expression),
+        optional($._quest)
+      ),
     _direct_or_indirect_binding: ($) =>
       seq(
         choice(
-          $.value_binding_pattern,
-          seq("case", generate_pattern_matching_rule($, true, false, false))
+          $._binding_kind_and_pattern,
+          seq("case", $._binding_pattern_no_expr)
         ),
         optional($.type_annotation)
       ),
-    wildcard_pattern: ($) => "_",
-    binding_pattern_kind: ($) => choice("var", "let"),
-    value_binding_pattern: ($) =>
-      prec.left(
-        choice(
-          seq("var", generate_pattern_matching_rule($, false, false)),
-          seq(
-            optional($._async_modifier),
-            "let",
-            generate_pattern_matching_rule($, false, false)
-          )
-        )
+    _binding_pattern_kind: ($) => field("mutability", choice("var", "let")),
+    _possibly_async_binding_pattern_kind: ($) =>
+      seq(optional($._async_modifier), $._binding_pattern_kind),
+    _binding_kind_and_pattern: ($) =>
+      seq(
+        $._possibly_async_binding_pattern_kind,
+        $._no_expr_pattern_already_bound
       ),
+    wildcard_pattern: ($) => "_",
+    _tuple_pattern_item: ($) =>
+      choice(
+        seq(
+          $.simple_identifier,
+          seq(":", alias($._binding_pattern_with_expr, $.pattern))
+        ),
+        alias($._binding_pattern_with_expr, $.pattern)
+      ),
+    _tuple_pattern: ($) => seq("(", sep1($._tuple_pattern_item, ","), ")"),
+    _case_pattern: ($) =>
+      seq(
+        optional("case"),
+        optional($.user_type), // XXX this should just be _type but that creates ambiguity
+        $._dot,
+        $.simple_identifier,
+        optional($._tuple_pattern)
+      ),
+    _type_casting_pattern: ($) =>
+      choice(
+        seq("is", $._type),
+        seq(alias($._binding_pattern_no_expr, $.pattern), $._as, $._type)
+      ),
+    _binding_pattern: ($) =>
+      seq(
+        seq(optional("case"), $._binding_pattern_kind),
+        $._no_expr_pattern_already_bound
+      ),
+
     // ==========
     // Modifiers
     // ==========
@@ -1735,87 +1774,6 @@ module.exports = grammar({
 });
 function sep1(rule, separator) {
   return seq(rule, repeat(seq(separator, rule)));
-}
-function generate_tuple_pattern($, allows_binding, allows_expressions) {
-  var pattern_rule = generate_pattern_matching_rule(
-    $,
-    allows_binding,
-    false,
-    allows_expressions
-  );
-  var tuple_pattern_item = choice(
-    seq($.simple_identifier, seq(":", pattern_rule)),
-    pattern_rule
-  );
-  return seq("(", sep1(tuple_pattern_item, ","), ")", optional($._quest));
-}
-function generate_case_pattern($, allows_binding, force) {
-  return seq(
-    optional($.user_type), // XXX this should just be _type but that creates ambiguity
-    $._dot,
-    $.simple_identifier,
-    optional(generate_tuple_pattern($, allows_binding, true)),
-    optional($._quest)
-  );
-}
-function generate_type_casting_pattern($, allows_binding) {
-  return choice(
-    seq("is", $._type),
-    seq(
-      generate_pattern_matching_rule($, allows_binding, false),
-      $._as,
-      $._type
-    )
-  );
-}
-function generate_pattern_matching_rule(
-  $,
-  allows_binding,
-  allows_case_keyword,
-  allows_expressions,
-  force
-) {
-  if (!force && !allows_case_keyword) {
-    if (allows_binding && !allows_expressions) {
-      return $.binding_pattern;
-    }
-    if (!allows_binding && !allows_expressions) {
-      return $.non_binding_pattern;
-    }
-    if (allows_binding && allows_expressions) {
-      return $._binding_pattern_with_expr;
-    }
-    if (!allows_binding && allows_expressions) {
-      return $._non_binding_pattern_with_expr;
-    }
-  }
-  var always_allowed_patterns = [
-    $.wildcard_pattern,
-    generate_tuple_pattern($, allows_binding, allows_expressions || false),
-    generate_type_casting_pattern($, allows_binding),
-  ];
-  var binding_pattern_prefix = allows_case_keyword
-    ? seq(optional("case"), $.binding_pattern_kind)
-    : $.binding_pattern_kind;
-  var binding_pattern_if_allowed = allows_binding
-    ? [
-        seq(
-          binding_pattern_prefix,
-          generate_pattern_matching_rule($, false, false, false)
-        ),
-      ]
-    : [];
-  var case_pattern = allows_case_keyword
-    ? seq("case", generate_case_pattern($, allows_binding))
-    : generate_case_pattern($, allows_binding);
-  var expression_pattern = allows_expressions
-    ? $._expression
-    : field("bound_identifier", $.simple_identifier);
-  var all_patterns = always_allowed_patterns
-    .concat(binding_pattern_if_allowed)
-    .concat(case_pattern)
-    .concat(expression_pattern);
-  return seq(choice.apply(void 0, all_patterns), optional($._quest));
 }
 
 function tree_sitter_version_supports_emoji() {

--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -27,7 +27,7 @@
 (type_parameter (type_identifier) @parameter)
 (inheritance_constraint (identifier (simple_identifier) @parameter))
 (equality_constraint (identifier (simple_identifier) @parameter))
-(non_binding_pattern bound_identifier: (simple_identifier)) @variable
+(pattern bound_identifier: (simple_identifier)) @variable
 
 [
   "typealias"
@@ -46,8 +46,8 @@
   (modify_specifier)
 ] @keyword
 
-(class_body (property_declaration (value_binding_pattern (non_binding_pattern (simple_identifier) @property))))
-(protocol_property_declaration (value_binding_pattern (non_binding_pattern (simple_identifier) @property)))
+(class_body (property_declaration (pattern (simple_identifier) @property)))
+(protocol_property_declaration (pattern (simple_identifier) @property))
 
 (import_declaration ["import" @include])
 
@@ -75,7 +75,6 @@
 ["while" "repeat" "continue" "break"] @repeat
 
 ["let" "var"] @keyword
-(non_binding_pattern (simple_identifier) @variable)
 
 (guard_statement ["guard" @conditional])
 (if_statement ["if" @conditional])

--- a/script-data/known_failures.txt
+++ b/script-data/known_failures.txt
@@ -1,4 +1,3 @@
 firefox-ios/Shared/Functions.swift
-RxSwift/RxExample/RxExample/Examples/GitHubSearchRepositories/GitHubSearchRepositories.swift
 SwiftLint/Source/SwiftLintFramework/Rules/Lint/ExpiringTodoRule.swift
 GRDB/GRDB/Core/Row.swift


### PR DESCRIPTION
This change loosens pattern validity requirements for the sake of greatly simplifying the grammar.

This isn't going to be backwards compatible, so let's take the opportunity to figure out what the names rules _should_ be for patterns -- the current `(value_binding_pattern (non_binding_pattern ... ))` situation is confusing.

It should be possible to do away with `generate_pattern_matching_rule` entirely. After doing that, finding the right combo of named rules (or maybe aliases) should make this mergeable.

See #9

Fixes #61
