### PR TITLE
Fix semicolon line attribution

### DIFF
--- a/src/scanner.c
+++ b/src/scanner.c
@@ -384,10 +384,12 @@ static enum ParseDirective eat_whitespace(
     uint32_t lookahead;
     while (should_treat_as_wspace(lookahead = lexer->lookahead)) {
         if (lookahead == ';') {
-            if (!semi_is_valid) {
-                break;
+            if (semi_is_valid) {
+                ws_directive = STOP_PARSING_TOKEN_FOUND;
+                lexer->advance(lexer, false);
             }
-            ws_directive = STOP_PARSING_TOKEN_FOUND;
+
+            break;
         }
 
         lexer->advance(lexer, true);


### PR DESCRIPTION
For some reason, we were continuing to look for more whitespace tokens after consuming an explicit semicolon. This is unnecessary since the scanner can just come back for the remaining whitespace, if any exists. It also leads to incorrect attribution of the location of the semicolon, so it's better to just break at the semicolon.

Fixes #177 -- with this change, the test file in that issue gets parsed as:

```
(source_file [0, 0] - [2, 0]
  (simple_identifier [0, 0] - [0, 3])
  (_semi [0, 3] - [0, 4])
  (simple_identifier [1, 0] - [1, 3])
  (_semi [1, 3] - [1, 4]))
```
