### PR TITLE
Split attribute argument into its own rule

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -95,6 +95,7 @@ module.exports = grammar({
   conflicts: ($) => [
     // @Type(... could either be an annotation constructor invocation or an annotated expression
     [$.attribute],
+    [$._attribute_argument],
     // Is `foo { ... }` a constructor invocation or function invocation?
     [$._simple_user_type, $._expression],
     // To support nested types A.B not being interpreted as `(navigation_expression ... (type_identifier)) (navigation_suffix)`
@@ -1584,25 +1585,18 @@ module.exports = grammar({
         "@",
         $.user_type,
         // attribute arguments are a mess of special cases, maybe this is good enough?
-        optional(
-          seq(
-            "(",
-            sep1(
-              choice(
-                // labeled function parameters, used in custom property wrappers
-                seq($.simple_identifier, ":", $._expression),
-                // Unlabeled function parameters, simple identifiers, or `*`
-                $._expression,
-                // References to param names (used in `@objc(foo:bar:)`)
-                repeat1(seq($.simple_identifier, ":")),
-                // Version restrictions (iOS 3.4.5, Swift 5.0.0)
-                seq(repeat1($.simple_identifier), sep1($.integer_literal, "."))
-              ),
-              ","
-            ),
-            ")"
-          )
-        )
+        optional(seq("(", sep1($._attribute_argument, ","), ")"))
+      ),
+    _attribute_argument: ($) =>
+      choice(
+        // labeled function parameters, used in custom property wrappers
+        seq($.simple_identifier, ":", $._expression),
+        // Unlabeled function parameters, simple identifiers, or `*`
+        $._expression,
+        // References to param names (used in `@objc(foo:bar:)`)
+        repeat1(seq($.simple_identifier, ":")),
+        // Version restrictions (iOS 3.4.5, Swift 5.0.0)
+        seq(repeat1($.simple_identifier), sep1($.integer_literal, "."))
       ),
     ////////////////////////////////
     // Patterns - https://docs.swift.org/swift-book/ReferenceManual/Patterns.html


### PR DESCRIPTION
Partially-addresses #132

Previously, ocaml-tree-sitter generated an anonymous CST node for this fragment, since the `sep1` helper function makes its first argument appear twice in the generated grammar. By naming it, ocaml-tree-sitter no longer has to come up with a name for this fragment when it extracts common grammar fragments.

A shift/reduce conflict between the first and third choice options exists. I believe that this was already covered by the `attribute` entry in the conflicts list, so I added `_attribute_argument` to that list as well. I do not believe that this is a true ambiguity in the grammar, since it could be resolved with arbitrary lookahead, so allowing tree sitter to explore both options should lead to a correct parse in all cases. I would appreciate a sanity check on my understanding here, though.