### PR TITLE
Split _modifierless_property_declaration rule

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -1229,19 +1229,18 @@ module.exports = grammar({
       prec.right(
         seq(
           $._possibly_async_binding_pattern_kind,
-          sep1(
-            seq(
-              field("name", alias($._no_expr_pattern_already_bound, $.pattern)),
-              optional($.type_annotation),
-              optional($.type_constraints),
-              optional(
-                choice(
-                  seq($._equal_sign, field("value", $._expression)),
-                  field("computed_value", $.computed_property)
-                )
-              )
-            ),
-            ","
+          sep1($._single_modifierless_property_declaration, ",")
+        )
+      ),
+    _single_modifierless_property_declaration: ($) =>
+      seq(
+        field("name", alias($._no_expr_pattern_already_bound, $.pattern)),
+        optional($.type_annotation),
+        optional($.type_constraints),
+        optional(
+          choice(
+            seq($._equal_sign, field("value", $._expression)),
+            field("computed_value", $.computed_property)
           )
         )
       ),


### PR DESCRIPTION
Partially addresses #132

The `sep1` helper makes its first argument appear twice in the generated grammar, so ocaml-tree-sitter pulls out that fragment. This gives that fragment a name so that it doesn't have to come up with one on its own.