### PR TITLE
Increase dynamic precedence of call

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -59,6 +59,11 @@ const PRECS = {
   comment: -3,
   lambda: -3,
 };
+
+const DYNAMIC_PRECS = {
+  call: 1,
+};
+
 const DEC_DIGITS = token(sep1(/[0-9]+/, /_+/));
 const HEX_DIGITS = token(sep1(/[0-9a-fA-F]+/, /_+/));
 const OCT_DIGITS = token(sep1(/[0-7]+/, /_+/));
@@ -756,7 +761,11 @@ module.exports = grammar({
       ),
     expr_hack_at_ternary_binary_call_suffix: ($) =>
       prec(PRECS.call_suffix, $.value_arguments),
-    call_expression: ($) => prec(PRECS.call, seq($._expression, $.call_suffix)),
+    call_expression: ($) =>
+      prec(
+        PRECS.call,
+        prec.dynamic(DYNAMIC_PRECS.call, seq($._expression, $.call_suffix))
+      ),
     _primary_expression: ($) =>
       choice(
         $.tuple_expression,


### PR DESCRIPTION
This is a weird one.

I found that under certain circumstances, the pattern `foo(1, 2)` was not matching the source file `foo(1, 2)` in Semgrep. When I looked at the CST generated by tree sitter, I found that if `foo(1, 2)` is followed by a newline, it is parsed as a call, but if it is not, it's parsed as a constructor. Often, patterns are provided over the command line and do not include a newline, whereas source files usually do. I tried to reproduce the difference in parsing using tree sitter directly, and could not. This puzzled me. I considered the possibility that the extensions we've made to the grammar to parse Semgrep constructs might have affected this, but that seemed far-fetched to me.

I recalled that calls and constructor calls are truly ambiguous with each other, so I decided to start looking into how they are resolved. There is an entry in the `conflicts` array for `_simple_user_type` vs `_expression`, which is where the conflict ultimately manifests. However, there weren't any relevant calls to `prec.dynamic` which would give the parser information on how to resolve the conflict at runtime. So, I formed the theory that tree sitter arbitrarily resolves it in one direction, whereas ocaml-tree-sitter's generated code sometimes arbitrarily resolves it in the other direction. I made the change here, propagated it over to Semgrep, and now have the desired behavior where Semgrep parses `foo(1, 2)` as a call whether or not it is followed by a newline.

Test plan: Automated tests, plus manual testing with Semgrep described above.