### PR TITLE
Fix locals scope

### DIFF
--- a/queries/locals.scm
+++ b/queries/locals.scm
@@ -15,4 +15,4 @@
  (function_declaration)
  (class_declaration)
  (protocol_declaration)
-] @scope
+] @local.scope


### PR DESCRIPTION
`@scope` is an invalid name according to documentation: https://tree-sitter.github.io/tree-sitter/syntax-highlighting#local-variables, therefore use `@local.scope`. This fixes tree-sitter cli that error on unknown `@scope`