### PR TITLE
Fix Nuke parse failures

### DIFF
--- a/corpus/functions.txt
+++ b/corpus/functions.txt
@@ -586,10 +586,10 @@ test { @Special [weak self, otherSelf] (a) in }
     (simple_identifier)
     (call_suffix
       (lambda_literal
+        (attribute
+          (user_type
+            (type_identifier)))
         (capture_list
-          (attribute
-            (user_type
-              (type_identifier)))
           (capture_list_item
             (ownership_modifier)
             (simple_identifier))
@@ -792,10 +792,11 @@ func multipleType() -> Foo & Bar { return Foo() }
               (value_arguments))))))))
 
 ================================================================================
-Annotated function parameters in lambdas
+Lambdas with annotations
 ================================================================================
 
 types.flatMap { @Sendable _ in }
+let mainClosure = { @MainActor in print("Running on main") }
 
 --------------------------------------------------------------------------------
 
@@ -807,10 +808,25 @@ types.flatMap { @Sendable _ in }
         (simple_identifier)))
     (call_suffix
       (lambda_literal
+        (attribute
+          (user_type
+            (type_identifier)))
         (lambda_function_type
           (lambda_function_type_parameters
             (lambda_parameter
-              (attribute
-                (user_type
-                  (type_identifier)))
-              (simple_identifier))))))))
+              (simple_identifier)))))))
+  (property_declaration
+    (pattern
+      (simple_identifier))
+    (lambda_literal
+      (attribute
+        (user_type
+          (type_identifier)))
+      (statements
+        (call_expression
+          (simple_identifier)
+          (call_suffix
+            (value_arguments
+              (value_argument
+                (line_string_literal
+                  (line_str_text))))))))))

--- a/corpus/types.txt
+++ b/corpus/types.txt
@@ -327,3 +327,34 @@ protocol GetType {
         (user_type
           (type_identifier)
           (type_identifier))))))
+
+================================================================================
+Existential types
+================================================================================
+
+let p: any P = S()
+func q(using p: any P) { }
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (property_declaration
+    (pattern
+      (simple_identifier))
+    (type_annotation
+      (existential_type
+        (user_type
+          (type_identifier))))
+    (call_expression
+      (simple_identifier)
+      (call_suffix
+        (value_arguments))))
+  (function_declaration
+    (simple_identifier)
+    (parameter
+      (simple_identifier)
+      (simple_identifier)
+      (existential_type
+        (user_type
+          (type_identifier))))
+    (function_body)))

--- a/grammar.js
+++ b/grammar.js
@@ -357,6 +357,7 @@ module.exports = grammar({
           $.optional_type,
           $.metatype,
           $.opaque_type,
+          $.existential_type,
           $.protocol_composition_type
         )
       ),
@@ -416,6 +417,7 @@ module.exports = grammar({
     _quest: ($) => "?",
     _immediate_quest: ($) => token.immediate("?"),
     opaque_type: ($) => seq("some", $.user_type),
+    existential_type: ($) => seq("any", $.user_type),
     protocol_composition_type: ($) =>
       prec.right(
         seq(


### PR DESCRIPTION
- Add support for existential types (`any Something`) -- these were defined in [SE-0335](https://github.com/apple/swift-evolution/blob/main/proposals/0335-existential-any.md) but don't appear to have made it into the official grammar yet.
- Fix placement of lambdas in annotations -- we were erroneously assigning those to parameters or capture clauses but in fact they only belong to the closure itself.
