### PR TITLE
Add SwiftPM manifest file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 node_modules
+/src/*
+!/src/scanner.c
 *.swp
 /build
 /test
@@ -9,3 +11,7 @@ Cargo.lock
 *.so
 *.o
 bindings/c/*.h
+bindings/c/tree-sitter-*.pc
+.vscode/
+.build/
+Package.resolved

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,30 @@
+// swift-tools-version: 5.6
+import PackageDescription
+
+let package = Package(
+  name: "TreeSitterSwift",
+  platforms: [.macOS(.v10_13), .iOS(.v11)],
+  products: [.library(name: "TreeSitterSwift", targets: ["TreeSitterSwift"])],
+  targets: [
+    .target(
+      name: "TreeSitterSwift",
+      path: ".",
+      exclude: [
+        "bindings",
+        "corpus",
+        "LICENSE",
+        "package.json",
+        "README.md",
+      ],
+      sources: [
+        "src/parser.c",
+        "src/scanner.c",
+      ],
+      resources: [
+        .copy("queries")
+      ],
+      publicHeadersPath: "bindings/swift",
+      cSettings: [.headerSearchPath("src")]
+    ),
+  ]
+)

--- a/bindings/c/tree-sitter.h.in
+++ b/bindings/c/tree-sitter.h.in
@@ -1,0 +1,16 @@
+#ifndef TREE_SITTER_@UPPER_PARSERNAME@_H_
+#define TREE_SITTER_@UPPER_PARSERNAME@_H_
+
+#include <tree_sitter/parser.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+extern TSLanguage *tree_sitter_@PARSERNAME@();
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // TREE_SITTER_@UPPER_PARSERNAME@_H_

--- a/bindings/c/tree-sitter.pc.in
+++ b/bindings/c/tree-sitter.pc.in
@@ -1,0 +1,11 @@
+prefix=@PREFIX@
+libdir=@LIBDIR@
+includedir=@INCLUDEDIR@
+additionallibs=@ADDITIONALLIBS@
+
+Name: tree-sitter-@PARSERNAME@
+Description: A tree-sitter grammar for the @PARSERNAME@ programming language.
+URL: @PARSERURL@
+Version: @VERSION@
+Libs: -L${libdir} ${additionallibs} -ltree-sitter-@PARSERNAME@
+Cflags: -I${includedir}

--- a/bindings/node/binding.cc
+++ b/bindings/node/binding.cc
@@ -1,0 +1,28 @@
+#include "tree_sitter/parser.h"
+#include <node.h>
+#include "nan.h"
+
+using namespace v8;
+
+extern "C" TSLanguage * tree_sitter_swift();
+
+namespace {
+
+NAN_METHOD(New) {}
+
+void Init(Local<Object> exports, Local<Object> module) {
+  Local<FunctionTemplate> tpl = Nan::New<FunctionTemplate>(New);
+  tpl->SetClassName(Nan::New("Language").ToLocalChecked());
+  tpl->InstanceTemplate()->SetInternalFieldCount(1);
+
+  Local<Function> constructor = Nan::GetFunction(tpl).ToLocalChecked();
+  Local<Object> instance = constructor->NewInstance(Nan::GetCurrentContext()).ToLocalChecked();
+  Nan::SetInternalFieldPointer(instance, 0, tree_sitter_swift());
+
+  Nan::Set(instance, Nan::New("name").ToLocalChecked(), Nan::New("swift").ToLocalChecked());
+  Nan::Set(module, Nan::New("exports").ToLocalChecked(), instance);
+}
+
+NODE_MODULE(tree_sitter_swift_binding, Init)
+
+}  // namespace

--- a/bindings/node/index.js
+++ b/bindings/node/index.js
@@ -1,0 +1,19 @@
+try {
+  module.exports = require("../../build/Release/tree_sitter_swift_binding");
+} catch (error1) {
+  if (error1.code !== "MODULE_NOT_FOUND") {
+    throw error1;
+  }
+  try {
+    module.exports = require("../../build/Debug/tree_sitter_swift_binding");
+  } catch (error2) {
+    if (error2.code !== "MODULE_NOT_FOUND") {
+      throw error2;
+    }
+    throw error1;
+  }
+}
+
+try {
+  module.exports.nodeTypeInfo = require("../../src/node-types.json");
+} catch (_) {}

--- a/bindings/rust/build.rs
+++ b/bindings/rust/build.rs
@@ -1,0 +1,19 @@
+fn main() {
+    let src_dir = std::path::Path::new("src");
+
+    let mut c_config = cc::Build::new();
+    c_config.include(&src_dir);
+    c_config
+        .flag_if_supported("-Wno-unused-parameter")
+        .flag_if_supported("-Wno-unused-but-set-variable")
+        .flag_if_supported("-Wno-trigraphs");
+    let parser_path = src_dir.join("parser.c");
+    c_config.file(&parser_path);
+
+    let scanner_path = src_dir.join("scanner.c");
+    c_config.file(&scanner_path);
+    println!("cargo:rerun-if-changed={}", scanner_path.to_str().unwrap());
+
+    c_config.compile("parser");
+    println!("cargo:rerun-if-changed={}", parser_path.to_str().unwrap());
+}

--- a/bindings/rust/lib.rs
+++ b/bindings/rust/lib.rs
@@ -1,0 +1,70 @@
+//! This crate provides swift language support for the [tree-sitter][] parsing library.
+//!
+//! Typically, you will use the [language][language func] function to add this language to a
+//! tree-sitter [Parser][], and then use the parser to parse some code:
+//!
+//! ```
+//! let code = "";
+//! let mut parser = tree_sitter::Parser::new();
+//! parser.set_language(tree_sitter_swift::language()).expect("Error loading swift grammar");
+//! let tree = parser.parse(code, None).unwrap();
+//! ```
+//!
+//! [Language]: https://docs.rs/tree-sitter/*/tree_sitter/struct.Language.html
+//! [language func]: fn.language.html
+//! [Parser]: https://docs.rs/tree-sitter/*/tree_sitter/struct.Parser.html
+//! [tree-sitter]: https://tree-sitter.github.io/
+
+use tree_sitter::Language;
+
+extern "C" {
+    fn tree_sitter_swift() -> Language;
+}
+
+/// Get the tree-sitter [Language][] for this grammar.
+///
+/// [Language]: https://docs.rs/tree-sitter/*/tree_sitter/struct.Language.html
+pub fn language() -> Language {
+    unsafe { tree_sitter_swift() }
+}
+
+/// The content of the [`node-types.json`][] file for this grammar.
+///
+/// [`node-types.json`]: https://tree-sitter.github.io/tree-sitter/using-parsers#static-node-types
+pub const NODE_TYPES: &'static str = include_str!("../../src/node-types.json");
+
+// Uncomment these to include any queries that this grammar contains
+
+pub const HIGHLIGHTS_QUERY: &'static str = include_str!("../../queries/highlights.scm");
+// pub const INJECTIONS_QUERY: &'static str = include_str!("../../queries/injections.scm");
+pub const LOCALS_QUERY: &'static str = include_str!("../../queries/locals.scm");
+pub const TAGS_QUERY: &'static str = include_str!("../../queries/tags.scm");
+
+#[cfg(test)]
+mod tests {
+    use anyhow::{anyhow, Result};
+
+    #[test]
+    fn test_can_load_grammar() -> Result<()> {
+        let mut parser = tree_sitter::Parser::new();
+        parser.set_language(super::language())?;
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_can_parse_basic_file() -> Result<()> {
+        let mut parser = tree_sitter::Parser::new();
+        parser.set_language(super::language())?;
+
+        let tree = parser.parse("_ = \"Hello!\"\n", None)
+            .ok_or_else(|| anyhow!("Unable to parse!"))?;
+
+        assert_eq!(
+            "(source_file (assignment target: (directly_assignable_expression (simple_identifier)) result: (line_string_literal text: (line_str_text))))",
+            tree.root_node().to_sexp(),
+        );
+
+        Ok(())
+    }
+}

--- a/bindings/swift/TreeSitterSwift/swift.h
+++ b/bindings/swift/TreeSitterSwift/swift.h
@@ -1,0 +1,17 @@
+#ifndef TREE_SITTER_SWIFT_H_
+#define TREE_SITTER_SWIFT_H_
+
+typedef struct TSLanguage TSLanguage;
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+extern TSLanguage *tree_sitter_swift();
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // TREE_SITTER_SWIFT_H_
+


### PR DESCRIPTION
This PR adds `Package.swift` and related files into the repository on the `with-generated-files` branch. This will get automatically updated on each new release, allowing downstream systems to consume the repository without needing to build from source.

Originally, the goal was to create a SwiftPM build tool that could compile all necessary files from source. This turned out to be infeasible because:

1. It would still require the `tree-sitter` _binaries_ to be checked into this repository. Why? Because `tree-sitter` normally distributes itself as binary (e.g. in the NPM [`install.js`](https://github.com/tree-sitter/tree-sitter/blob/a882d0b036b0da23cde5caa1325089b4ca4750ba/cli/npm/install.js) which just wraps a download script) but SwiftPM builds are sandboxed. This is unfortunate, but not infeasible, since a 10MB checked-in artifact that never changes isn't the end of the world.
2. There appears to be a bug with `BuildToolPlugin` dependency resolution that causes their execution not to be added into the build plan when a `ClangTarget` (C-family target) depends on them. This is expecially pernicious since a `ClangTarget` can't declare a dependency on a `SwiftTarget`. It was possible (easy, even) to get a binary `tree-sitter` dependency to run on a `SwiftTarget`, but there's no way to force that to run before this C code generation. Even a very sneaky approach like having a build tool depend on a package that depends on binary generation ended up not working. I plan to file a bug on it, but since the first problem already makes this system somewhat unfortunate, that was the point where I caved.

Fixes #175﻿
