### PR TITLE
Treat foo() { } as one call, not two

### DIFF
--- a/corpus/expressions.txt
+++ b/corpus/expressions.txt
@@ -783,19 +783,17 @@ let keyPathStringExpression = #keyPath(someProperty)
             (simple_identifier)
             (integer_literal))))))
   (call_expression
-    (call_expression
-      (navigation_expression
-        (simple_identifier)
-        (navigation_suffix
-          (simple_identifier)))
-      (call_suffix
-        (value_arguments
-          (value_argument
-            (navigation_expression
-              (key_path_expression)
-              (navigation_suffix
-                (simple_identifier)))))))
+    (navigation_expression
+      (simple_identifier)
+      (navigation_suffix
+        (simple_identifier)))
     (call_suffix
+      (value_arguments
+        (value_argument
+          (navigation_expression
+            (key_path_expression)
+            (navigation_suffix
+              (simple_identifier)))))
       (lambda_literal
         (lambda_function_type
           (lambda_function_type_parameters
@@ -1126,20 +1124,18 @@ async(async: async, qos: qos, flags: flags) {
 
 (source_file
   (call_expression
-    (call_expression
-      (simple_identifier)
-      (call_suffix
-        (value_arguments
-          (value_argument
-            (simple_identifier)
-            (simple_identifier))
-          (value_argument
-            (simple_identifier)
-            (simple_identifier))
-          (value_argument
-            (simple_identifier)
-            (simple_identifier)))))
+    (simple_identifier)
     (call_suffix
+      (value_arguments
+        (value_argument
+          (simple_identifier)
+          (simple_identifier))
+        (value_argument
+          (simple_identifier)
+          (simple_identifier))
+        (value_argument
+          (simple_identifier)
+          (simple_identifier)))
       (lambda_literal
         (statements
           (call_expression

--- a/corpus/functions.txt
+++ b/corpus/functions.txt
@@ -514,13 +514,11 @@ test(2) { $0.doSomething() }
 
 (source_file
   (call_expression
-    (call_expression
-      (simple_identifier)
-      (call_suffix
-        (value_arguments
-          (value_argument
-            (integer_literal)))))
+    (simple_identifier)
     (call_suffix
+      (value_arguments
+        (value_argument
+          (integer_literal)))
       (lambda_literal
         (statements
           (call_expression


### PR DESCRIPTION
Fixes #2 (Finally!)

This requires us to introduce a conflict since call arguments can be
neither left associative nor right associative.
