### PR TITLE
Disallow `lazy` as a local variable modifier

### DIFF
--- a/corpus/classes.txt
+++ b/corpus/classes.txt
@@ -1514,3 +1514,41 @@ private actor CounterActor {
                         (simple_identifier)
                         (call_suffix
                           (value_arguments))))))))))))))
+
+================================================================================
+Lazy is usable as a computed property
+================================================================================
+
+extension Array {
+    var stringified: some RandomAccessCollection {
+        lazy.map { "\($0)" }
+    }
+}
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (class_declaration
+    (user_type
+      (type_identifier))
+    (class_body
+      (property_declaration
+        (pattern
+          (simple_identifier))
+        (type_annotation
+          (opaque_type
+            (user_type
+              (type_identifier))))
+        (computed_property
+          (statements
+            (call_expression
+              (navigation_expression
+                (simple_identifier)
+                (navigation_suffix
+                  (simple_identifier)))
+              (call_suffix
+                (lambda_literal
+                  (statements
+                    (line_string_literal
+                      (interpolated_expression
+                        (simple_identifier)))))))))))))

--- a/grammar.js
+++ b/grammar.js
@@ -1730,14 +1730,11 @@ module.exports = grammar({
         $.function_modifier,
         $.mutation_modifier,
         $.property_modifier,
-        $.parameter_modifier
+        $.parameter_modifier,
+        $.property_behavior_modifier
       ),
     _locally_permitted_modifier: ($) =>
-      choice(
-        $.ownership_modifier,
-        $.property_behavior_modifier,
-        $.inheritance_modifier
-      ),
+      choice($.ownership_modifier, $.inheritance_modifier),
     property_behavior_modifier: ($) => "lazy",
     type_modifiers: ($) => repeat1($.attribute),
     member_modifier: ($) =>

--- a/script-data/known_failures.txt
+++ b/script-data/known_failures.txt
@@ -1,3 +1,2 @@
 firefox-ios/Shared/Functions.swift
 SwiftLint/Source/SwiftLintFramework/Rules/Lint/ExpiringTodoRule.swift
-GRDB/GRDB/Core/Row.swift


### PR DESCRIPTION
Because this is technically not allowed, allowing it here means that we end up _disallowing_ `lazy` as an identifier in local scope (which is wrong -- it's a default function on collections!)

This fixes a top-repo error!
