### PR TITLE
Move custom operator handling to `scanner.c`

### DIFF
--- a/.github/workflows/top-repos.yml
+++ b/.github/workflows/top-repos.yml
@@ -55,6 +55,16 @@ jobs:
           - 41
           - 42
           - 43
+          - 44
+          - 45
+          - 46
+          - 47
+          - 48
+          - 49
+          - 50
+          - 51
+          - 52
+          - 53
     steps:
     - uses: actions/checkout@v2
     - name: Use Node.js ${{ matrix.node-version }}

--- a/corpus/expressions.txt
+++ b/corpus/expressions.txt
@@ -1142,3 +1142,24 @@ async(async: async, qos: qos, flags: flags) {
             (simple_identifier)
             (call_suffix
               (value_arguments))))))))
+
+================================================================================
+Assigning to the result of a force unwrap
+================================================================================
+
+stat[lang]! += 1
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (assignment
+    (directly_assignable_expression
+      (postfix_expression
+        (call_expression
+          (simple_identifier)
+          (call_suffix
+            (value_arguments
+              (value_argument
+                (simple_identifier)))))
+        (bang)))
+    (integer_literal)))

--- a/corpus/functions.txt
+++ b/corpus/functions.txt
@@ -354,6 +354,8 @@ precedencegroup MyPrecedence {
 
 infix operator -=- : MyPrecedence
 
+infix operator •
+
 --------------------------------------------------------------------------------
 
 (source_file
@@ -371,7 +373,9 @@ infix operator -=- : MyPrecedence
         (simple_identifier))))
   (operator_declaration
     (custom_operator)
-    (simple_identifier)))
+    (simple_identifier))
+  (operator_declaration
+    (custom_operator)))
 
 ================================================================================
 Custom operator with another operator as a prefix

--- a/grammar.js
+++ b/grammar.js
@@ -853,7 +853,7 @@ module.exports = grammar({
       prec.left(
         PRECS.lambda,
         seq(
-          "{",
+          choice("{", "^{"),
           optional($._lambda_type_declaration),
           optional($.statements),
           "}"

--- a/script-data/known_failures.txt
+++ b/script-data/known_failures.txt
@@ -1,1 +1,1 @@
-firefox-ios/Shared/Functions.swift
+ReactKit/ReactKitTests/OperationTests.swift

--- a/script-data/top-repositories.txt
+++ b/script-data/top-repositories.txt
@@ -41,3 +41,13 @@ Nuke kean/Nuke 11.1.1
 Swinject Swinject/Swinject 2.8.2
 GRDB groue/GRDB.swift v6.0.0-beta.3 0 2
 GRDB groue/GRDB.swift v6.0.0-beta.3 1 2
+Dance saoudrizwan/Dance v1.0.7
+StyleKit 146BC/StyleKit 0.7.0
+ReactKit ReactKit/ReactKit 0.12.0
+JASON delba/JASON 3.1.1
+Side-Menu Yalantis/Side-Menu.iOS 2.0.2
+C4iOS C4Labs/C4iOS 3.0.1
+Taylor izqui/Taylor 0.4.5
+Runes thoughtbot/Runes v5.1.0
+Overdrive saidsikira/Overdrive 0.3
+Tactile delba/Tactile 3.0.1


### PR DESCRIPTION
Custom operator rules are better expressed as conditions to track in `eat_operator` vs a series of impenetrable regexes.

Also requires a fix for an undiscovered bug where `x[...]!` was not considered to be a legal target for an expression. Since the old logic allowed `+=` to be a "custom operator", we were covering up for that failure by interpreting `x[...]! += y` as a custom infix expression.

This fixes the last parse failure in the current list of top repos, so we also bring in some new top repos. The new list comes from the ones the Semgrep folks have added for their own parse rate tracking. For some reason, Semgrep uses very old repos, so we have to support older language constructs.

Fixes #5
