### PR TITLE
Fix impossible pattern in highlight queries

### DIFF
--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -73,7 +73,7 @@
 ; Statements
 (for_statement ["for" @repeat])
 (for_statement ["in" @repeat])
-(for_statement item: (simple_identifier) @variable)
+(for_statement (pattern) @variable)
 (else) @keyword
 (as_operator) @keyword
 


### PR DESCRIPTION
After the pattern refactor, the highlight query for `for_statement` was never updated, and now refers to a pattern that cannot happen (a `simple_identifier` directly under a `for_statement`). In addition to being wrong, this gets rejected by older versions of `tree-sitter`.

Fixes #219
