### PR TITLE
Check queries against older tree-sitter versions

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -11,17 +11,12 @@ jobs:
 
     runs-on: ubuntu-latest
 
-    strategy:
-      matrix:
-        node-version: [12.x, 14.x, 16.x]
-        # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
-
     steps:
     - uses: actions/checkout@v2
-    - name: Use Node.js ${{ matrix.node-version }}
+    - name: Use Node.js 16.x
       uses: actions/setup-node@v2
       with:
-        node-version: ${{ matrix.node-version }}
+        node-version: 16.x
         cache: 'npm'
     - uses: actions-rs/toolchain@v1
       with:

--- a/.github/workflows/test-older-tree-sitter.yml
+++ b/.github/workflows/test-older-tree-sitter.yml
@@ -1,0 +1,23 @@
+name: Check compilation on tree-sitter 0.19
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Use Node.js 16.x
+      uses: actions/setup-node@v2
+      with:
+        node-version: 16.x
+        cache: 'npm'
+    - run: cp package-json-old-tree-sitter.json package.json
+    - run: npm install
+    - run: npx tree-sitter test -f "Does not match any named tests; only runs queries."

--- a/package-json-old-tree-sitter.json
+++ b/package-json-old-tree-sitter.json
@@ -1,0 +1,41 @@
+{
+  "name": "tree-sitter-swift",
+  "version": "0.0.0-old-tree-sitter",
+  "description": "A tree-sitter grammar for the Swift programming language.",
+  "main": "bindings/node/index.js",
+  "scripts": {
+    "install": "node scripts/wait-for-tree-sitter.js && tree-sitter generate"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/alex-pinkus/tree-sitter-swift.git"
+  },
+  "tree-sitter": [
+    {
+      "scope": "source.swift",
+      "file-types": [
+        "swift"
+      ],
+      "injection-regex": "swift"
+    }
+  ],
+  "keywords": [
+    "parser",
+    "swift"
+  ],
+  "author": "Alex Pinkus <alex.pinkus@gmail.com>",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/alex-pinkus/tree-sitter-swift/issues"
+  },
+  "homepage": "https://github.com/alex-pinkus/tree-sitter-swift#readme",
+  "dependencies": {
+    "nan": "^2.15.0",
+    "tree-sitter-cli": "=0.19.0",
+    "which": "2.0.2"
+  },
+  "devDependencies": {
+    "node-gyp": "^8.4.1",
+    "prettier": "2.3.2"
+  }
+}


### PR DESCRIPTION
In #221, we fixed a bug where older versions of tree-sitter failed to parse highlight queries because they were impossible.

Since we know that some editors use an older version of tree-sitter, it would be prudent to test against it in CI.
