### PR TITLE
Fix operator handling with custom ops that start with `/`, and with `...`

### DIFF
--- a/corpus/expressions.txt
+++ b/corpus/expressions.txt
@@ -1163,3 +1163,39 @@ stat[lang]! += 1
                 (simple_identifier)))))
         (bang)))
     (integer_literal)))
+
+================================================================================
+Tricky operators
+================================================================================
+
+/!5;
+
+prefix operator /!;
+prefix func /!(x: Int) {
+    print(x)
+}
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (prefix_expression
+    (custom_operator)
+    (integer_literal))
+  (operator_declaration
+    (custom_operator))
+  (function_declaration
+    (modifiers
+      (function_modifier))
+    (custom_operator)
+    (parameter
+      (simple_identifier)
+      (user_type
+        (type_identifier)))
+    (function_body
+      (statements
+        (call_expression
+          (simple_identifier)
+          (call_suffix
+            (value_arguments
+              (value_argument
+                (simple_identifier)))))))))

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -1,5 +1,8 @@
 #include <tree_sitter/parser.h>
+#include <string.h>
 #include <wctype.h>
+
+#define TOKEN_COUNT 29
 
 enum TokenType {
     BLOCK_COMMENT,
@@ -117,7 +120,7 @@ const enum TokenType OP_SYMBOLS[OPERATOR_COUNT] = {
     ASYNC_KEYWORD
 };
 
-#define RESERVED_OP_COUNT 28
+#define RESERVED_OP_COUNT 30
 
 const char* RESERVED_OPS[RESERVED_OP_COUNT] = {
     "/",
@@ -135,6 +138,7 @@ const char* RESERVED_OPS[RESERVED_OP_COUNT] = {
     "?",
     "~",
     ".",
+    "..",
     "->",
     "/*",
     "*/",
@@ -147,7 +151,8 @@ const char* RESERVED_OPS[RESERVED_OP_COUNT] = {
     "<<",
     "++",
     "--",
-    "==="
+    "===",
+    "..."
 };
 
 bool is_cross_semi_token(enum TokenType op) {
@@ -785,11 +790,16 @@ bool tree_sitter_swift_external_scanner_scan(
         return false;
     }
 
+    bool valid_operators[TOKEN_COUNT];
+    memcpy(valid_operators, valid_symbols, TOKEN_COUNT);
+    if (has_ws_result) {
+        valid_operators[THREE_DOT_OPERATOR] = false;
+    }
     // Now consume any operators that might cause our whitespace to be suppressed.
     enum TokenType operator_result;
     bool saw_operator = eat_operators(
                             lexer,
-                            valid_symbols,
+                            valid_operators,
                             /* mark_end */ true,
                             comment == CONTINUE_PARSING_SLASH_CONSUMED ? '/' : '\0',
                             &operator_result


### PR DESCRIPTION
- Fix handling of custom operators when a slash was already consumed:
  - This logic was not working properly when the whitespace handler attempted to consume a slash already. To handle that, we give the `eat_operator` function some more information about the surrounding context of the possible prior character that has been eaten.

- Don't allow a three-dot operator after a newline:
  - The Swift compiler actually doesn't allow this with _any_ whitespace around it, but that's more annoying to accomplish. Instead, we simply hard-code the three dot operator as "invalid" if we've already crossed over an implicit semicolon boundary. Once we emit the `_semi`, the three-dot operator will no longer be legal anymore, so it will be missed on the next pass as well.
  - We don't add a test for this because tests for error conditions are somewhat brittle. If there are a lot more of this sort of thing, it might be worth investing in some custom infrastructure to test _that_ certain snippets fail without having to assert _exactly_ the failing structure.
