### PR TITLE
Don't use the external scanner for `...`

### DIFF
--- a/corpus/expressions.txt
+++ b/corpus/expressions.txt
@@ -1111,7 +1111,9 @@ let a = false
     (pattern
       (simple_identifier))
     (boolean_literal))
-  (simple_identifier))
+  (prefix_expression
+    (bang)
+    (simple_identifier)))
 
 ================================================================================
 Calling `async` in positions where it could be a keyword
@@ -1199,3 +1201,19 @@ prefix func /!(x: Int) {
             (value_arguments
               (value_argument
                 (simple_identifier)))))))))
+
+================================================================================
+Three dot operator after newline
+================================================================================
+
+foo()
+...
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (call_expression
+    (simple_identifier)
+    (call_suffix
+      (value_arguments)))
+  (fully_open_range))

--- a/grammar.js
+++ b/grammar.js
@@ -211,8 +211,6 @@ module.exports = grammar({
     // Every one of the below operators will suppress a `_semi` if we encounter it after a newline.
     $._arrow_operator_custom,
     $._dot_custom,
-    $._three_dot_operator_custom,
-    $._open_ended_range_operator_custom,
     $._conjunction_operator_custom,
     $._disjunction_operator_custom,
     $._nil_coalescing_operator_custom,
@@ -1017,6 +1015,8 @@ module.exports = grammar({
     _assignment_and_operator: ($) => choice("+=", "-=", "*=", "/=", "%=", "="),
     _equality_operator: ($) => choice("!=", "!==", $._eq_eq, "==="),
     _comparison_operator: ($) => choice("<", ">", "<=", ">="),
+    _three_dot_operator: ($) => alias("...", "..."), // Weird alias to satisfy highlight queries
+    _open_ended_range_operator: ($) => alias("..<", "..<"),
     _is_operator: ($) => "is",
     _additive_operator: ($) =>
       choice(
@@ -1435,9 +1435,6 @@ module.exports = grammar({
     _eq_eq: ($) => alias($._eq_eq_custom, "=="),
     _dot: ($) => alias($._dot_custom, "."),
     _arrow_operator: ($) => alias($._arrow_operator_custom, "->"),
-    _three_dot_operator: ($) => alias($._three_dot_operator_custom, "..."),
-    _open_ended_range_operator: ($) =>
-      alias($._open_ended_range_operator_custom, "..<"),
     _conjunction_operator: ($) => alias($._conjunction_operator_custom, "&&"),
     _disjunction_operator: ($) => alias($._disjunction_operator_custom, "||"),
     _nil_coalescing_operator: ($) =>


### PR DESCRIPTION
We now have better invalidation of operators in the custom scanner than we did when we added the various `.`-prefixed operators. This means we can bail out quickly and avoid marking a token incorrectly.

This simplifies downstream handling of `...`, which, in addition to being a Swift operator, is also used by Semgrep.

In order to make this happen, we do also have to be a bit more careful with `mark_end`. If we're possibly going to emit a `_semi`, we have to make sure not to `mark_end`, because we don't want that to be "part of" the semi. This theoretically means that if we were chasing a longer operator, but failed to find it, and had a shorter operator that was `cross_semi`, it would get parsed incorrectly -- but this seems unlikely since such a longer operator would be likely to match the `custom_operator` pattern to begin with.

Fixes #226
