### PR TITLE
Regenerate parser.c in Makefile when grammar changes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -107,6 +107,10 @@ install: all
 	install -d '$(DESTDIR)$(PCLIBDIR)'
 	install -m644 bindings/c/tree-sitter-$(PARSER_NAME).pc '$(DESTDIR)$(PCLIBDIR)'/
 
+# Regenerate the parser if the grammar file is newer.
+src/parser.c: grammar.js
+	npx tree-sitter generate
+
 clean:
 	rm -f $(OBJ) libtree-sitter-$(PARSER_NAME).a libtree-sitter-$(PARSER_NAME).$(SOEXT) libtree-sitter-$(PARSER_NAME).$(SOEXTVER_MAJOR) libtree-sitter-$(PARSER_NAME).$(SOEXTVER)
 	rm -f bindings/c/$(PARSER_NAME).h bindings/c/tree-sitter-$(PARSER_NAME).pc


### PR DESCRIPTION
Currently, a non-clean build after updating `grammar.js` will not pick up any new changes. This happens because as far as the makefile is concerned, `parser.c` is a source file, and it has not been updated.

To fix this, we simply add a rule that can generate `parser.c`. If someone runs `make install` after `npm install`, this rule will do nothing, because the output file will already be newer. However, if someone updates the repo, this will ensure all artifacts get updated.

Fixes #229

