### PR TITLE
Ignore SPM .build directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ Cargo.lock
 bindings/c/*.h
 bindings/c/tree-sitter-*.pc
 .vscode/
+/.build


### PR DESCRIPTION
Super minor, but I noticed it was missing.