### PR TITLE
Pin tree-sitter-cli to 0.20.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "homepage": "https://github.com/alex-pinkus/tree-sitter-swift#readme",
   "dependencies": {
     "nan": "^2.15.0",
-    "tree-sitter-cli": "^0.20.6",
+    "tree-sitter-cli": "=0.20.6",
     "which": "2.0.2"
   },
   "devDependencies": {


### PR DESCRIPTION
Somewhat ironically, we must opt out of the ABI 14 query improvements that were turned on by default in 0.20.7. That's because no version of `node-tree-sitter` has been published that supports ABI 14. Hopefully this is a temporary state that we can fix later!

Fixes #236
