### PR TITLE
Use ABI-14 parser when compiling for SPM

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -17,7 +17,7 @@ let package = Package(
         "README.md",
       ],
       sources: [
-        "src/parser.c",
+        "src/parser_abi14.c",
         "src/scanner.c",
       ],
       resources: [


### PR DESCRIPTION
`SwiftTreeSitter`, which we know practically is the one package wrapping `tree-sitter` that builds in SPM, uses a git submodule that points to 0.20.7. Before it did that, it didn't pin a version in the submodule, and before it had submodules it pointed to a fork of `tree-sitter` directly.

Because of this, we know that it's extremely unlikely that anyone would build `tree-sitter-swift` in SPM and require ABI 13 compatibility. This is different from, say, NPM, where we know the opposite is true. However, because we know this here, we can significantly speed up query parsing by using ABI 14.

On my local machine, this consistently halved the time it took to run a simple test that just loaded queries and did nothing else.

Before:
```
real	0m4.376s
user	0m4.262s
sys	0m0.118s
```

After:
```
real	0m2.057s
user	0m1.937s
sys	0m0.109s
```
