### PR TITLE
Add await to highlighted keywords

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -772,7 +772,7 @@ module.exports = grammar({
           )
         )
       ),
-    _await_operator: ($) => "await",
+    _await_operator: ($) => alias("await", "await"),
     ternary_expression: ($) =>
       prec.right(
         PRECS.ternary,

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "license": "MIT",
       "dependencies": {
         "nan": "^2.15.0",
-        "tree-sitter-cli": "^0.20.6",
+        "tree-sitter-cli": "=0.20.6",
         "which": "2.0.2"
       },
       "devDependencies": {

--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -21,6 +21,7 @@
 (function_declaration ["init" @constructor])
 (throws) @keyword
 "async" @keyword
+"await" @keyword
 (where_keyword) @keyword
 (parameter external_name: (simple_identifier) @parameter)
 (parameter name: (simple_identifier) @parameter)


### PR DESCRIPTION
Requires a redundant alias to get it to show up as a node.

Also updated an out-of-date package lock.
