### PR TITLE
Allow lazy as a local modifier

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -173,6 +173,9 @@ module.exports = grammar({
     [$._modifierless_class_declaration, $.property_modifier],
     [$._modifierless_class_declaration, $.simple_identifier],
     [$._fn_call_lambda_arguments],
+
+    // `lazy` is also allowed as an identifier...
+    [$.property_behavior_modifier, $.simple_identifier],
   ],
   extras: ($) => [
     $.comment,
@@ -261,7 +264,8 @@ module.exports = grammar({
         /`[^\r\n` ]*`/,
         /\$[0-9]+/,
         token(seq("$", LEXICAL_IDENTIFIER)),
-        "actor"
+        "actor",
+        "lazy"
       ),
     identifier: ($) => sep1($.simple_identifier, $._dot),
     // Literals
@@ -1751,11 +1755,14 @@ module.exports = grammar({
         $.function_modifier,
         $.mutation_modifier,
         $.property_modifier,
-        $.parameter_modifier,
-        $.property_behavior_modifier
+        $.parameter_modifier
       ),
     _locally_permitted_modifier: ($) =>
-      choice($.ownership_modifier, $.inheritance_modifier),
+      choice(
+        $.ownership_modifier,
+        $.inheritance_modifier,
+        $.property_behavior_modifier
+      ),
     property_behavior_modifier: ($) => "lazy",
     type_modifiers: ($) => repeat1($.attribute),
     member_modifier: ($) =>

--- a/script-data/top-repositories.txt
+++ b/script-data/top-repositories.txt
@@ -1,7 +1,7 @@
 Alamofire Alamofire/Alamofire 5.6.4
 iina iina/iina v1.3.1
 Charts danielgindi/Charts v4.1.0
-lottie-ios airbnb/lottie-ios 4.0.1
+lottie-ios airbnb/lottie-ios 4.1.3
 vapor vapor/vapor 3.3.3
 SwiftyJSON SwiftyJSON/SwiftyJSON 5.0.1
 RxSwift ReactiveX/RxSwift 6.5.0 0 9


### PR DESCRIPTION
The keyword `lazy` can also be used as an identifier. Previously, we resolved this by saying it wasn't usable in local scope, but that's not actually quite right. We just have to define it in both places and let it conflict like `actor` does.
