### PR TITLE
Regenerate using ABI 14 before publishing to crates.io

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -37,6 +37,7 @@ jobs:
             override: true
       - run: npm install
       - run: npm run test-ci
+      - run: npx tree-sitter generate --abi 14
       - run: cargo test
       - uses: katyo/publish-crates@v1
         with:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ include = [
 path = "bindings/rust/lib.rs"
 
 [dependencies]
-tree-sitter = "~0.20.0"
+tree-sitter = "^0.20.4"
 
 [build-dependencies]
 cc = "1.0"


### PR DESCRIPTION
ABI 14 has been out for a year, so it's time to bump our version constraints.

Fixes  #271