### PR TITLE
Created a separate identifier for constructors

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -2,32 +2,31 @@ name: Check compilation/bindings/style
 
 on:
   push:
-    branches: [ main ]
+    branches: [main]
   pull_request:
-    branches: [ main ]
+    branches: [main]
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Use Node.js 16.x
-      uses: actions/setup-node@v2
-      with:
-        node-version: 16.x
-        cache: 'npm'
-    - uses: actions-rs/toolchain@v1
-      with:
+      - uses: actions/checkout@v2
+      - name: Use Node.js 16.x
+        uses: actions/setup-node@v2
+        with:
+          node-version: 16.x
+          cache: "npm"
+      - uses: actions-rs/toolchain@v1
+        with:
           toolchain: stable
           override: true
-    - run: npm install
-    - run: npm run ci
-    - run: npm run test-ci
-    - run: make install
-      env:
+      - run: npm install
+      - run: npm run ci
+      - run: npm run test-ci
+      - run: make install
+        env:
           PREFIX: /tmp
-    - run: cargo test
-    - run: cd ./test-npm-package && npm test; cd -
-    - run: npm pack && cd .. && npm install -g ./tree-sitter-swift/tree-sitter-swift-*.tgz; cd -
+      - run: cargo test
+      - run: cd ./test-npm-package && npm test; cd -
+      - run: npm pack && cd .. && npm install -g ./tree-sitter-swift/tree-sitter-swift-*.tgz; cd -

--- a/.github/workflows/generate-static-grammar.yml
+++ b/.github/workflows/generate-static-grammar.yml
@@ -3,7 +3,7 @@ name: Check in static grammar files
 on:
   push:
     tags:
-      - '*'
+      - "*"
 
 jobs:
   generate_grammar:

--- a/.github/workflows/parser-src.yml
+++ b/.github/workflows/parser-src.yml
@@ -2,22 +2,22 @@ name: Publish `grammar.json` and `parser.c`
 
 on:
   push:
-    branches: [ main ]
+    branches: [main]
 
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - name: Use Node.js
-      uses: actions/setup-node@v2
-      with:
-        node-version: 16.x
-        cache: 'npm'
-    - run: npm install
-    - run: npm run test-ci
-    - name: Publish parser source
-      uses: actions/upload-artifact@v2
-      with:
-        name: generated-parser-src
-        path: src
+      - uses: actions/checkout@v2
+      - name: Use Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version: 16.x
+          cache: "npm"
+      - run: npm install
+      - run: npm run test-ci
+      - name: Publish parser source
+        uses: actions/upload-artifact@v2
+        with:
+          name: generated-parser-src
+          path: src

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -33,16 +33,16 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:
-            toolchain: stable
-            override: true
+          toolchain: stable
+          override: true
       - run: npm install
       - run: npm run test-ci
       - run: npx tree-sitter generate --abi 14
       - run: cargo test
       - uses: katyo/publish-crates@v1
         with:
-            registry-token: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-            args: --allow-dirty
+          registry-token: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+          args: --allow-dirty
   badge_update:
     runs-on: ubuntu-latest
     needs:
@@ -53,7 +53,7 @@ jobs:
         uses: RubbaBoy/BYOB@v1.3.0
         with:
           NAME: crates_io_version
-          LABEL: 'crates.io'
+          LABEL: "crates.io"
           STATUS: ${{ needs.npm_publish.outputs.package_version }}
           COLOR: green
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -61,7 +61,7 @@ jobs:
         uses: RubbaBoy/BYOB@v1.3.0
         with:
           NAME: npm_version
-          LABEL: 'npm'
+          LABEL: "npm"
           STATUS: ${{ needs.npm_publish.outputs.package_version }}
           COLOR: green
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test-older-tree-sitter.yml
+++ b/.github/workflows/test-older-tree-sitter.yml
@@ -2,24 +2,23 @@ name: Check compilation on tree-sitter 0.19
 
 on:
   push:
-    branches: [ main ]
+    branches: [main]
   pull_request:
-    branches: [ main ]
+    branches: [main]
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Use Node.js 16.x
-      uses: actions/setup-node@v2
-      with:
-        node-version: 16.x
-        cache: 'npm'
-    - run: cp package-json-old-tree-sitter.json package.json
-    - run: npm install
-    # corpus tests fail and highlight tests are extremely slow; just remove them!
-    - run: rm -r test
-    - run: npx tree-sitter test
+      - uses: actions/checkout@v2
+      - name: Use Node.js 16.x
+        uses: actions/setup-node@v2
+        with:
+          node-version: 16.x
+          cache: "npm"
+      - run: cp package-json-old-tree-sitter.json package.json
+      - run: npm install
+      # corpus tests fail and highlight tests are extremely slow; just remove them!
+      - run: rm -r test
+      - run: npx tree-sitter test

--- a/.github/workflows/top-repos.yml
+++ b/.github/workflows/top-repos.yml
@@ -2,9 +2,9 @@ name: Parse top repositories
 
 on:
   push:
-    branches: [ main ]
+    branches: [main]
   pull_request:
-    branches: [ main ]
+    branches: [main]
 
 jobs:
   build:
@@ -66,14 +66,14 @@ jobs:
           - 52
           - 53
     steps:
-    - uses: actions/checkout@v2
-    - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v2
-      with:
-        node-version: '16.x'
-        cache: 'npm'
-    - run: npm install
-    - run: ./scripts/top-repos.sh ${{matrix.repo}}
+      - uses: actions/checkout@v2
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v2
+        with:
+          node-version: "16.x"
+          cache: "npm"
+      - run: npm install
+      - run: ./scripts/top-repos.sh ${{matrix.repo}}
   badge_gen:
     runs-on: ubuntu-latest
     needs: build
@@ -85,8 +85,8 @@ jobs:
         if: ${{ github.event_name == 'push' }}
         uses: RubbaBoy/BYOB@v1.3.0
         with:
-            NAME: parse_rate
-            LABEL: 'Parse rate'
-            STATUS: ${{ steps.parse_rate.outputs.parse_rate }}
-            COLOR: blue
-            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NAME: parse_rate
+          LABEL: "Parse rate"
+          STATUS: ${{ steps.parse_rate.outputs.parse_rate }}
+          COLOR: blue
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/update-repos.yml
+++ b/.github/workflows/update-repos.yml
@@ -2,7 +2,7 @@ name: Update corpus repository versions
 
 on:
   schedule:
-    - cron: '12 4 * * 0'
+    - cron: "12 4 * * 0"
 
 jobs:
   update_repository_versions:

--- a/README.md
+++ b/README.md
@@ -12,7 +12,9 @@ This contains a [`tree-sitter`](https://tree-sitter.github.io/tree-sitter) gramm
 To use this parser to parse Swift code, you'll want to depend on either the Rust crate or the NPM package.
 
 ### Rust
+
 To use the Rust crate, you'll add this to your `Cargo.toml`:
+
 ```
 tree-sitter = "0.20.4"
 tree-sitter-swift = "=0.3.6"
@@ -33,6 +35,7 @@ let tree = parser.parse(&my_source_code, None)
 ### Javascript
 
 To use this from NPM, you'll add similar dependencies to `package.json`:
+
 ```
 "dependencies: {
   "tree-sitter-swift": "0.3.6",
@@ -41,6 +44,7 @@ To use this from NPM, you'll add similar dependencies to `package.json`:
 ```
 
 Your usage of the parser will look like:
+
 ```
 const Parser = require("tree-sitter");
 const Swift = require("tree-sitter-swift");
@@ -59,8 +63,8 @@ With this package checked out, a common workflow for editing the grammar will lo
 
 1. Make a change to `grammar.ts`.
 2. Run `npm install && npm test` to see whether the change has had impact on existing parsing behavior. The default
-`npm test` target requires `valgrind` to be installed; if you do not have it installed, and do not wish to, you can
-substitute `tree-sitter test` directly.
+   `npm test` target requires `valgrind` to be installed; if you do not have it installed, and do not wish to, you can
+   substitute `tree-sitter test` directly.
 3. Run `tree-sitter parse` on some real Swift codebase and see whether (or where) it fails.
 4. Use any failures to create new corpus test cases.
 
@@ -71,36 +75,34 @@ started this parser to teach myself how `tree-sitter` works, and how to write a 
 you have an issue with the parser, please file a bug and include a test case to put in the `corpus`. I can't promise any
 level of support, but having the test case makes it more likely that I want to tinker with it.
 
-## Using tree-sitter-swift in Web Assembly 
-To use tree-sitter-swift as a language for the web bindings version  tree-sitter, which will likely be a more modern version than the published node
+## Using tree-sitter-swift in Web Assembly
+
+To use tree-sitter-swift as a language for the web bindings version tree-sitter, which will likely be a more modern version than the published node
 module. [see](https://github.com/tree-sitter/tree-sitter/blob/master/lib/binding_web/README.md). Follow the instructions below
 
 1. Install the node modules `npm install web-tree-sitter tree-sitter-swift`
 2. Run the tree-sitter cli to create the wasm bundle
-    ```sh
-    $ npx tree-sitter build-asm ./node_modules/tree-sitter 
-    ```
+   ```sh
+   $ npx tree-sitter build-asm ./node_modules/tree-sitter
+   ```
 3. Boot tree-sitter wasm like this.
 
 ```js
-
 const Parser = require("web-tree-sitter");
-async function run(){
-    //needs to happen first 
-    await Parser.init();
-    //wait for the load of swift
-    const Swift = await Parser.Language.load('./tree-sitter-swift.wasm');
+async function run() {
+  //needs to happen first
+  await Parser.init();
+  //wait for the load of swift
+  const Swift = await Parser.Language.load("./tree-sitter-swift.wasm");
 
-    const parser = new Parser();
-    parser.setLanguage(Swift);
+  const parser = new Parser();
+  parser.setLanguage(Swift);
 
-    //Parse your swift code here.
-    const tree = parser.parse('print("Hello, World!")')
+  //Parse your swift code here.
+  const tree = parser.parse('print("Hello, World!")');
 }
 //if you want to run this
 run().then(console.log, console.error);
-
-
 ```
 
 ## Frequently asked questions
@@ -118,8 +120,9 @@ and your library version are compatible.
 
 If you need a `parser.c`, and you don't care about the tree-sitter version, but you don't have a local setup that would
 allow you to obtain the parser, you can just download one from a recent workflow run in this package. To do so:
-* Go to the [GitHub actions page](https://github.com/alex-pinkus/tree-sitter-swift/actions) for this
+
+- Go to the [GitHub actions page](https://github.com/alex-pinkus/tree-sitter-swift/actions) for this
   repository.
-* Click on the "Publish `grammar.json` and `parser.c`" action for the appropriate commit.
-* Go down to `Artifacts` and click on `generated-parser-src`. All the relevant parser files will be available in your
+- Click on the "Publish `grammar.json` and `parser.c`" action for the appropriate commit.
+- Go down to `Artifacts` and click on `generated-parser-src`. All the relevant parser files will be available in your
   download.

--- a/grammar.js
+++ b/grammar.js
@@ -143,6 +143,7 @@ module.exports = grammar({
     ],
     // The `class` modifier is legal in many of the same positions that a class declaration itself would be.
     [$._bodyless_function_declaration, $.property_modifier],
+    [$.init_declaration, $.property_modifier],
     [$._local_class_declaration, $.modifiers],
     // Patterns, man
     [$._navigable_type_expression, $._case_pattern],
@@ -1201,6 +1202,7 @@ module.exports = grammar({
         $.property_declaration,
         $.typealias_declaration,
         $.function_declaration,
+        $.init_declaration,
         $.class_declaration,
         $.protocol_declaration,
         $.operator_declaration,
@@ -1213,6 +1215,7 @@ module.exports = grammar({
         $.property_declaration,
         $.typealias_declaration,
         $.function_declaration,
+        $.init_declaration,
         $.class_declaration,
         $.protocol_declaration,
         $.deinit_declaration,
@@ -1329,10 +1332,7 @@ module.exports = grammar({
     _modifierless_function_declaration_no_body: ($) =>
       prec.right(
         seq(
-          choice(
-            $._constructor_function_decl,
-            $._non_constructor_function_decl
-          ),
+          $._non_constructor_function_decl,
           optional($.type_parameters),
           $._function_value_parameters,
           optional($._async_keyword),
@@ -1435,8 +1435,6 @@ module.exports = grammar({
         field("type", $._possibly_implicitly_unwrapped_type),
         optional($._three_dot_operator)
       ),
-    _constructor_function_decl: ($) =>
-      seq(field("name", "init"), optional(choice($._quest, $.bang))),
     _non_constructor_function_decl: ($) =>
       seq(
         "func",
@@ -1541,11 +1539,16 @@ module.exports = grammar({
           ),
           $.protocol_function_declaration
         ),
+        $.init_declaration,
         $.deinit_declaration,
         $.protocol_property_declaration,
         $.typealias_declaration,
         $.associatedtype_declaration,
         $.subscript_declaration
+      ),
+    init_declaration: ($) =>
+      prec.right(
+        seq(optional($.modifiers), optional("class"), field("name", "init"), optional(choice($._quest, $.bang)), $._function_value_parameters, field("body", $.function_body)),
       ),
     deinit_declaration: ($) =>
       prec.right(

--- a/grammar.js
+++ b/grammar.js
@@ -1548,7 +1548,14 @@ module.exports = grammar({
       ),
     init_declaration: ($) =>
       prec.right(
-        seq(optional($.modifiers), optional("class"), field("name", "init"), optional(choice($._quest, $.bang)), $._function_value_parameters, field("body", $.function_body)),
+        seq(
+          optional($.modifiers),
+          optional("class"),
+          field("name", "init"),
+          optional(choice($._quest, $.bang)),
+          $._function_value_parameters,
+          field("body", $.function_body)
+        )
       ),
     deinit_declaration: ($) =>
       prec.right(

--- a/package-json-old-tree-sitter.json
+++ b/package-json-old-tree-sitter.json
@@ -13,16 +13,11 @@
   "tree-sitter": [
     {
       "scope": "source.swift",
-      "file-types": [
-        "swift"
-      ],
+      "file-types": ["swift"],
       "injection-regex": "swift"
     }
   ],
-  "keywords": [
-    "parser",
-    "swift"
-  ],
+  "keywords": ["parser", "swift"],
   "author": "Alex Pinkus <alex.pinkus@gmail.com>",
   "license": "MIT",
   "bugs": {

--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -18,7 +18,7 @@
 ] @keyword
 
 (function_declaration (simple_identifier) @method)
-(function_declaration ["init" @constructor])
+(init_declaration ["init" @constructor])
 (throws) @keyword
 "async" @keyword
 "await" @keyword

--- a/queries/tags.scm
+++ b/queries/tags.scm
@@ -13,7 +13,7 @@
             (subscript_declaration
                 (parameter (simple_identifier) @name)
             )
-            (function_declaration "init" @name)
+            (init_declaration "init" @name)
             (deinit_declaration "deinit" @name)
         ]
     )

--- a/queries/tags.scm
+++ b/queries/tags.scm
@@ -28,7 +28,7 @@
             (subscript_declaration
                 (parameter (simple_identifier) @name)
             )
-            (protocol_function_declaration "init" @name)
+            (init_declaration "init" @name)
         ]
     )
 ) @definition.method

--- a/test/corpus/classes.txt
+++ b/test/corpus/classes.txt
@@ -800,7 +800,7 @@ class Test {
         (type_annotation
           (user_type
             (type_identifier))))
-      (function_declaration
+      (init_declaration
         (parameter
           (simple_identifier)
           (simple_identifier)
@@ -827,7 +827,7 @@ class Test {
                   (navigation_suffix
                     (simple_identifier))))
               (simple_identifier)))))
-      (function_declaration
+      (init_declaration
         (modifiers
           (member_modifier)
           (member_modifier))
@@ -844,7 +844,7 @@ class Test {
                     (integer_literal))
                   (value_argument
                     (integer_literal))))))))
-      (function_declaration
+      (init_declaration
         (modifiers
           (member_modifier))
         (parameter
@@ -864,7 +864,7 @@ class Test {
                     (integer_literal))
                   (value_argument
                     (integer_literal))))))))
-      (function_declaration
+      (init_declaration
         (modifiers
           (member_modifier))
         (bang)

--- a/test/corpus/statements.txt
+++ b/test/corpus/statements.txt
@@ -915,7 +915,7 @@ public init() {
 --------------------------------------------------------------------------------
 
 (source_file
-  (function_declaration
+  (init_declaration
     (modifiers
       (visibility_modifier))
     (function_body


### PR DESCRIPTION
Added init_declaration for constructors to deffrentiate between constructors and function calls in tree-sitter query without using comparators for name.

Example:
```
class c1 {
   init() {
   }
}
```
can be parsed as 
```
(class_declaration [0, 0] - [3, 1]
    name: (type_identifier [0, 6] - [0, 8])
    body: (class_body [0, 9] - [3, 1]
      (init_declaration [1, 4] - [2, 5]
        body: (function_body [1, 11] - [2, 5])))))
```

For issue: https://github.com/alex-pinkus/tree-sitter-swift/issues/285