### PR TITLE
Parse compiler directives with the contained statements

### DIFF
--- a/test/corpus/statements.txt
+++ b/test/corpus/statements.txt
@@ -958,13 +958,14 @@ Compiler diagnostics
 --------------------------------------------------------------------------------
 
 (source_file
-  (directive)
-  (diagnostic)
-  (directive)
-  (diagnostic)
-  (directive)
-  (directive)
-  (directive))
+  (directive
+    (compilation_condition
+      (simple_identifier))
+    (diagnostic)
+    (compilation_condition
+      (simple_identifier))
+    (diagnostic)
+    (directive)))
 
 ================================================================================
 Async let


### PR DESCRIPTION
In Swift, directives like `#if DEBUG` can only appear in statement
position. This means that we can include them in the syntax tree in ways
we wouldn't be able to if they could appear arbitrarily.
