### PR TITLE
Add initial textobjects.scm

### DIFF
--- a/queries/textobjects.scm
+++ b/queries/textobjects.scm
@@ -1,0 +1,19 @@
+
+
+; MARK: Structure
+
+(function_declaration
+  body: (_) @function.inside) @function.around
+
+; TODO: Classes/structs/enums
+
+
+; MARK: Tests
+
+; Only matches prefix test. Other conventions
+; might be nice to add!
+(function_declaration
+	name: (simple_identifier) @_name
+	(#match? @_name "^test")
+)
+


### PR DESCRIPTION
Hi!

I also noticed there wasn't a `textobjects.scm`, and decided to take a crack at it -- this allows for inter-function, (almost) inter-test jumping in [helix](https://github.com/helix-editor/helix), for instance :)

Happy to add more or if y'all want to use as a jumping off point, feel free.

I got setup with the [playground](https://tree-sitter.github.io/tree-sitter/playground), which was relatively simple on macOS:
```sh
brew install tree-sitter
brew install emscripten
tree-sitter build-wasm
tree-sitter playground
```