### PR TITLE
Remove unpublished top repository

### DIFF
--- a/.github/workflows/top-repos.yml
+++ b/.github/workflows/top-repos.yml
@@ -64,7 +64,6 @@ jobs:
           - 50
           - 51
           - 52
-          - 53
     steps:
     - uses: actions/checkout@v2
     - name: Use Node.js ${{ matrix.node-version }}

--- a/script-data/top-repositories.txt
+++ b/script-data/top-repositories.txt
@@ -19,7 +19,6 @@ shadowsocks shadowsocks/ShadowsocksX-NG v1.10.2
 SnapKit SnapKit/SnapKit 5.0.1
 SwiftLint realm/SwiftLint 0.51.0 0 2
 SwiftLint realm/SwiftLint 0.51.0 1 2
-ClashX yichengchen/clashX 1.98.0
 Carthage Carthage/Carthage 0.39.0
 Rectangle rxhanson/Rectangle v0.68
 PromiseKit mxcl/PromiseKit 6.22.1


### PR DESCRIPTION
The repository yichengchen/clashX seems to no longer exist. This will
cause CI to fail until it's removed.
