### PR TITLE
Allow assignment to be split over multiple lines

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -1084,7 +1084,8 @@ module.exports = grammar({
       ),
     _try_operator_type: ($) =>
       choice(token.immediate("!"), token.immediate("?")),
-    _assignment_and_operator: ($) => choice("+=", "-=", "*=", "/=", "%=", "="),
+    _assignment_and_operator: ($) =>
+      choice("+=", "-=", "*=", "/=", "%=", $._equal_sign),
     _equality_operator: ($) => choice("!=", "!==", $._eq_eq, "==="),
     _comparison_operator: ($) => choice("<", ">", "<=", ">="),
     _three_dot_operator: ($) => alias("...", "..."), // Weird alias to satisfy highlight queries

--- a/script-data/known_failures.txt
+++ b/script-data/known_failures.txt
@@ -1,3 +1,2 @@
 ReactKit/ReactKitTests/OperationTests.swift
 GRDB/GRDB/Core/Statement.swift
-lottie-ios/Sources/Public/Animation/LottieAnimationLayer.swift

--- a/test/corpus/expressions.txt
+++ b/test/corpus/expressions.txt
@@ -1550,3 +1550,17 @@ let result = try !(inner1() || inner2())
                   (simple_identifier)
                   (call_suffix
                     (value_arguments)))))))))))
+
+================================================================================
+Assignment split over multiple lines
+================================================================================
+savedValue
+  = 0
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (assignment
+    (directly_assignable_expression
+      (simple_identifier))
+    (integer_literal)))


### PR DESCRIPTION
Since this case used a literal "=" in the grammar, rather than an `_equal_sign`, it did not indicate to the scanner that the `=` was an allowed character. This prevented the scanner from suppressing semicolons.
