### PR TITLE
Bring back support for optional types in constructors

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -428,7 +428,10 @@ module.exports = grammar({
         )
       ),
     tuple_type: ($) =>
-      seq("(", optional(sep1(field("element", $.tuple_type_item), ",")), ")"),
+      choice(
+        seq("(", optional(sep1(field("element", $.tuple_type_item), ",")), ")"),
+        alias($._parenthesized_type, $.tuple_type_item)
+      ),
     tuple_type_item: ($) =>
       prec(
         PRECS.expr,
@@ -534,7 +537,10 @@ module.exports = grammar({
     _parenthesized_type: ($) =>
       seq(
         "(",
-        choice($.opaque_type, $.existential_type, $.dictionary_type),
+        field(
+          "element",
+          choice($.opaque_type, $.existential_type, $.dictionary_type)
+        ),
         ")"
       ),
     navigation_expression: ($) =>

--- a/script-data/known_failures.txt
+++ b/script-data/known_failures.txt
@@ -1,2 +1,1 @@
 ReactKit/ReactKitTests/OperationTests.swift
-GRDB/GRDB/Core/Statement.swift

--- a/test/corpus/expressions.txt
+++ b/test/corpus/expressions.txt
@@ -1564,3 +1564,80 @@ savedValue
     (directly_assignable_expression
       (simple_identifier))
     (integer_literal)))
+
+================================================================================
+Optional type in array constructor
+================================================================================
+
+var values = [(any Value)?]()
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (property_declaration
+    (value_binding_pattern)
+    (pattern
+      (simple_identifier))
+    (constructor_expression
+      (array_type
+        (optional_type
+          (tuple_type
+            (tuple_type_item
+              (existential_type
+                (user_type
+                  (type_identifier)))))))
+      (constructor_suffix
+        (value_arguments)))))
+
+================================================================================
+Anonymous lambda parameter
+================================================================================
+completionRegistrar.addCompletion { (_) in
+    print("Completed")
+}
+--------------------------------------------------------------------------------
+
+(source_file
+  (call_expression
+    (navigation_expression
+      (simple_identifier)
+      (navigation_suffix
+        (simple_identifier)))
+    (call_suffix
+      (lambda_literal
+        (lambda_function_type
+          (lambda_function_type_parameters
+            (lambda_parameter
+              (simple_identifier))))
+        (statements
+          (call_expression
+            (simple_identifier)
+            (call_suffix
+              (value_arguments
+                (value_argument
+                  (line_string_literal
+                    (line_str_text)))))))))))
+
+================================================================================
+Wildcard assignment as first line of lambda
+================================================================================
+
+doLast {
+    _ = doSomething()
+}
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (call_expression
+    (simple_identifier)
+    (call_suffix
+      (lambda_literal
+        (statements
+          (assignment
+            (directly_assignable_expression
+              (simple_identifier))
+            (call_expression
+              (simple_identifier)
+              (call_suffix
+                (value_arguments)))))))))


### PR DESCRIPTION
In #353, adding `_parenthesized_type` caused new parse failures where the parser now resolved away from `tuple_type` too early. Specifically, when parsing an expression like `[(any Foo) ...`, the `tuple_type` interpretation must still be valid at that point in the expression in case we're about to see a `?`.

The truly robust thing to do would be to support `$.tuple_type` as the target of the navigation expression. However, this leads to a large number of additional parse failures, as seen in #360. To avoid all of that, we add support in the opposite direction: allow `tuple_type` to be resolved using `_parenthesized_type`, so that the parser seeing the latter does not cause it to invalidate the former.
