### PR TITLE
Highlight Self and defer appropriately

### DIFF
--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -5,6 +5,7 @@
 (attribute) @variable
 (type_identifier) @type
 (self_expression) @variable.builtin
+(user_type (type_identifier) @variable.builtin (#eq? @variable.builtin "Self"))
 
 ; Declarations
 "func" @keyword.function
@@ -69,6 +70,7 @@
 ((navigation_expression
    (simple_identifier) @type) ; SomeType.method(): highlight SomeType as a type
    (#match? @type "^[A-Z]"))
+(call_expression (simple_identifier) @keyword (#eq? @keyword "defer")) ; defer { ... }
 
 (try_operator) @operator
 (try_operator ["try" @keyword])
@@ -168,4 +170,3 @@
  "..<"
  "..."
 ] @operator
-


### PR DESCRIPTION
Adds special case `#eq?` clauses into the highlight queries for special cases where we have keywords or builtins that aren't in the grammar.

Specifically:
* With `Self`, this is parsed as a boring type identifier, but should be
  highlighted as a builtin variable.
* With `defer { }`, this is parsed as a function, but the behavior is
  unique enough that it is reasonable to present it as a keyword.

With this and other recent fixes, all of the issues identified in #351 have been fixed.
