### PR TITLE
Highlight `deinit` the same as `init`.

### DIFF
--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -20,6 +20,7 @@
 
 (function_declaration (simple_identifier) @method)
 (function_declaration ["init" @constructor])
+(function_declaration ["deinit" @constructor])
 (throws) @keyword
 "async" @keyword
 "await" @keyword

--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -20,7 +20,7 @@
 
 (function_declaration (simple_identifier) @method)
 (function_declaration ["init" @constructor])
-(function_declaration ["deinit" @constructor])
+(deinit_declaration ["deinit" @constructor])
 (throws) @keyword
 "async" @keyword
 "await" @keyword
@@ -45,7 +45,7 @@
   "override"
   "convenience"
   "required"
-  "mutating" 
+  "mutating"
   "associatedtype"
 ] @keyword
 


### PR DESCRIPTION
@IronHam notes that it seems jarring to see an init and then deinit method declared in succession where only one gets a special highlighting.