### PR TITLE
Add willSet/didSet to indents

### DIFF
--- a/queries/indents.scm
+++ b/queries/indents.scm
@@ -31,6 +31,9 @@
   (array_literal)               ; [ foo, bar ]
   (dictionary_literal)          ; [ foo: bar, x: y ]
   (lambda_literal) 
+  (willset_didset_block)
+  (willset_clause)
+  (didset_clause)
 ] @indent.begin
 
 ; @something(...)


### PR DESCRIPTION
Copied from https://github.com/nvim-treesitter/nvim-treesitter/pull/6242

Indent tests were not copied because I could not find a way to invoke them from `tree-sitter test`. We'll just have to be more careful in the future.
