### PR TITLE
Loosen tree-sitter dependency versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,3 +27,4 @@ cc = "1.0"
 
 [dev-dependencies]
 anyhow = "1.0"
+tree-sitter = "0.22.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,4 +27,4 @@ cc = "1.0"
 
 [dev-dependencies]
 anyhow = "1.0"
-tree-sitter = "0.22.1"
+tree-sitter = "0.20.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ include = [
 path = "bindings/rust/lib.rs"
 
 [dependencies]
-tree-sitter = "^0.20.4"
+tree-sitter = ">=0.20.4, <0.23.0"
 
 [build-dependencies]
 cc = "1.0"


### PR DESCRIPTION
`tree-sitter` has released changes that are breaking within its library itself, but that do not bump the ABI_VERSION. This means that although the `tree-sitter` "major version" has changed, this is compatible across major versions.
