### PR TITLE
Recognize `distributed` as a modifier on actors and functions.

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -1911,7 +1911,8 @@ module.exports = grammar({
     type_parameter_modifiers: ($) => repeat1($.attribute),
     function_modifier: ($) => choice("infix", "postfix", "prefix"),
     mutation_modifier: ($) => choice("mutating", "nonmutating"),
-    property_modifier: ($) => choice("static", "dynamic", "optional", "class", "distributed"),
+    property_modifier: ($) =>
+      choice("static", "dynamic", "optional", "class", "distributed"),
     inheritance_modifier: ($) => choice("final"),
     parameter_modifier: ($) =>
       choice(

--- a/grammar.js
+++ b/grammar.js
@@ -1911,7 +1911,7 @@ module.exports = grammar({
     type_parameter_modifiers: ($) => repeat1($.attribute),
     function_modifier: ($) => choice("infix", "postfix", "prefix"),
     mutation_modifier: ($) => choice("mutating", "nonmutating"),
-    property_modifier: ($) => choice("static", "dynamic", "optional", "class"),
+    property_modifier: ($) => choice("static", "dynamic", "optional", "class", "distributed"),
     inheritance_modifier: ($) => choice("final"),
     parameter_modifier: ($) =>
       choice(

--- a/test/corpus/classes.txt
+++ b/test/corpus/classes.txt
@@ -1664,3 +1664,25 @@ class ForceUpdateEnacter {
                     (value_argument
                       (line_string_literal
                         (line_str_text)))))))))))))
+
+================================================================================
+Distributed actors and functions
+================================================================================
+
+distributed actor A {
+  distributed func doit() {}
+}
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (class_declaration
+    (modifiers
+      (property_modifier))
+    (type_identifier)
+    (class_body
+      (function_declaration
+        (modifiers
+          (property_modifier))
+        (simple_identifier)
+        (function_body)))))


### PR DESCRIPTION
I elected to specify this as a `property_modifier` given that it's a property of both actors and functions. I considered creating a whole `actor_declaration` node but that seemed a little much. Happy to move this around if needs be.

<img width="236" alt="image" src="https://github.com/alex-pinkus/tree-sitter-swift/assets/2498/f74935e2-8f46-4bfd-b14a-d2476f585205">
