### PR TITLE
Highlight precedencegroup components.

### DIFF
--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -52,6 +52,14 @@
 (opaque_type ["some" @keyword])
 (existential_type ["any" @keyword])
 
+(precedence_group_declaration
+ ["precedencegroup" @keyword]
+ (simple_identifier) @type)
+(precedence_group_attribute
+ (simple_identifier) @keyword
+ [(simple_identifier) @type
+  (boolean_literal) @boolean])
+
 [
   (getter_specifier)
   (setter_specifier)


### PR DESCRIPTION
<img width="331" alt="image" src="https://github.com/alex-pinkus/tree-sitter-swift/assets/2498/6a4be618-08b2-40fc-8189-27620b1abd6f">

(the missing highlighting for `true` above is a tree-sitter bug, I believe)