### PR TITLE
Add injections for regex highlighting.

### DIFF
--- a/bindings/rust/lib.rs
+++ b/bindings/rust/lib.rs
@@ -36,7 +36,7 @@ pub const NODE_TYPES: &'static str = include_str!("../../src/node-types.json");
 // Uncomment these to include any queries that this grammar contains
 
 pub const HIGHLIGHTS_QUERY: &'static str = include_str!("../../queries/highlights.scm");
-// pub const INJECTIONS_QUERY: &'static str = include_str!("../../queries/injections.scm");
+pub const INJECTIONS_QUERY: &'static str = include_str!("../../queries/injections.scm");
 pub const LOCALS_QUERY: &'static str = include_str!("../../queries/locals.scm");
 pub const TAGS_QUERY: &'static str = include_str!("../../queries/tags.scm");
 
@@ -57,7 +57,8 @@ mod tests {
         let mut parser = tree_sitter::Parser::new();
         parser.set_language(super::language())?;
 
-        let tree = parser.parse("_ = \"Hello!\"\n", None)
+        let tree = parser
+            .parse("_ = \"Hello!\"\n", None)
             .ok_or_else(|| anyhow!("Unable to parse!"))?;
 
         assert_eq!(

--- a/queries/injections.scm
+++ b/queries/injections.scm
@@ -1,0 +1,4 @@
+; Parse regex syntax within regex literals
+
+((regex_literal) @injection.content
+ (#set! injection.language "regex"))


### PR DESCRIPTION
This will allow components of regexen to be highlighted on GitHub, in the manner of those in JS and Ruby.