### PR TITLE
Add support for SE-0393

### DIFF
--- a/test/corpus/functions.txt
+++ b/test/corpus/functions.txt
@@ -1168,3 +1168,211 @@ struct Foo {
         (simple_identifier)
         (function_body))
       (comment))))
+
+================================================================================
+Parameter pack in generic parameters
+================================================================================
+
+func < <each Element: Comparable>(lhs: (repeat each Element), rhs: (repeat each Element)) -> Bool { }
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (function_declaration
+    (type_parameters
+      (type_parameter
+        (type_parameter_pack
+          (user_type
+            (type_identifier)))
+        (user_type
+          (type_identifier))))
+    (parameter
+      (simple_identifier)
+      (tuple_type
+        (tuple_type_item
+          (type_pack_expansion
+            (type_parameter_pack
+              (user_type
+                (type_identifier)))))))
+    (parameter
+      (simple_identifier)
+      (tuple_type
+        (tuple_type_item
+          (type_pack_expansion
+            (type_parameter_pack
+              (user_type
+                (type_identifier)))))))
+    (user_type
+      (type_identifier))
+    (function_body)))
+
+================================================================================
+Parameter pack in type constraints
+================================================================================
+
+func zip<each S>(_ sequence: repeat each S) where repeat each S: Sequence { }
+func variadic<each S: Sequence, T>(_: repeat each S) where repeat (each S).Element == T {}
+func variadic<each S: Sequence, each T>(_: repeat each S) where repeat (each S).Element == Array<each T> {}
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (function_declaration
+    (simple_identifier)
+    (type_parameters
+      (type_parameter
+        (type_parameter_pack
+          (user_type
+            (type_identifier)))))
+    (parameter
+      (simple_identifier)
+      (simple_identifier)
+      (type_pack_expansion
+        (type_parameter_pack
+          (user_type
+            (type_identifier)))))
+    (type_constraints
+      (where_keyword)
+      (type_constraint
+        (inheritance_constraint
+          (type_pack_expansion
+            (type_parameter_pack
+              (user_type
+                (type_identifier))))
+          (user_type
+            (type_identifier)))))
+    (function_body))
+  (function_declaration
+    (simple_identifier)
+    (type_parameters
+      (type_parameter
+        (type_parameter_pack
+          (user_type
+            (type_identifier)))
+        (user_type
+          (type_identifier)))
+      (type_parameter
+        (type_identifier)))
+    (parameter
+      (simple_identifier)
+      (type_pack_expansion
+        (type_parameter_pack
+          (user_type
+            (type_identifier)))))
+    (type_constraints
+      (where_keyword)
+      (type_constraint
+        (equality_constraint
+          (type_pack_expansion
+            (tuple_type
+              (tuple_type_item
+                (type_parameter_pack
+                  (user_type
+                    (type_identifier))))))
+          (simple_identifier)
+          (user_type
+            (type_identifier)))))
+    (function_body))
+  (function_declaration
+    (simple_identifier)
+    (type_parameters
+      (type_parameter
+        (type_parameter_pack
+          (user_type
+            (type_identifier)))
+        (user_type
+          (type_identifier)))
+      (type_parameter
+        (type_parameter_pack
+          (user_type
+            (type_identifier)))))
+    (parameter
+      (simple_identifier)
+      (type_pack_expansion
+        (type_parameter_pack
+          (user_type
+            (type_identifier)))))
+    (type_constraints
+      (where_keyword)
+      (type_constraint
+        (equality_constraint
+          (type_pack_expansion
+            (tuple_type
+              (tuple_type_item
+                (type_parameter_pack
+                  (user_type
+                    (type_identifier))))))
+          (simple_identifier)
+          (user_type
+            (type_identifier)
+            (type_arguments
+              (type_parameter_pack
+                (user_type
+                  (type_identifier))))))))
+    (function_body)))
+
+================================================================================
+Parameter pack soup
+================================================================================
+
+func makePairs<each First, each Second>(
+  firsts first: repeat each First,
+  seconds second: repeat each Second
+) -> (repeat Pair<each First, each Second>) {
+  return (repeat Pair(each first, each second))
+}
+--------------------------------------------------------------------------------
+
+(source_file
+  (function_declaration
+    (simple_identifier)
+    (type_parameters
+      (type_parameter
+        (type_parameter_pack
+          (user_type
+            (type_identifier))))
+      (type_parameter
+        (type_parameter_pack
+          (user_type
+            (type_identifier)))))
+    (parameter
+      (simple_identifier)
+      (simple_identifier)
+      (type_pack_expansion
+        (type_parameter_pack
+          (user_type
+            (type_identifier)))))
+    (parameter
+      (simple_identifier)
+      (simple_identifier)
+      (type_pack_expansion
+        (type_parameter_pack
+          (user_type
+            (type_identifier)))))
+    (tuple_type
+      (tuple_type_item
+        (type_pack_expansion
+          (user_type
+            (type_identifier)
+            (type_arguments
+              (type_parameter_pack
+                (user_type
+                  (type_identifier)))
+              (type_parameter_pack
+                (user_type
+                  (type_identifier))))))))
+    (function_body
+      (statements
+        (control_transfer_statement
+          (tuple_expression
+            (call_expression
+              (value_pack_expansion
+                (simple_identifier))
+              (call_suffix
+                (value_arguments
+                  (value_argument
+                    (value_parameter_pack
+                      (simple_identifier)))
+                  (value_argument
+                    (value_parameter_pack
+                      (simple_identifier))))))))))))

--- a/test/corpus/statements.txt
+++ b/test/corpus/statements.txt
@@ -217,7 +217,8 @@ while let .ok(data) = doWork() {
 
 repeat {
     // ...
-} while something()
+}
+while something()
 
 --------------------------------------------------------------------------------
 
@@ -1108,3 +1109,73 @@ actor.increment()
         (simple_identifier)))
     (call_suffix
       (value_arguments))))
+
+================================================================================
+`repeat` as an enum case name
+================================================================================
+
+extension LottieLoopMode: Equatable {
+  public static func == (lhs: LottieLoopMode, rhs: LottieLoopMode) -> Bool {   
+    switch (lhs, rhs) {
+    case (.repeat(let lhsAmount), .repeat(let rhsAmount)):
+      return lhsAmount == rhsAmount
+    default:
+      return false
+    }
+  }
+}
+
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (class_declaration
+    (user_type
+      (type_identifier))
+    (inheritance_specifier
+      (user_type
+        (type_identifier)))
+    (class_body
+      (function_declaration
+        (modifiers
+          (visibility_modifier)
+          (property_modifier))
+        (parameter
+          (simple_identifier)
+          (user_type
+            (type_identifier)))
+        (parameter
+          (simple_identifier)
+          (user_type
+            (type_identifier)))
+        (user_type
+          (type_identifier))
+        (function_body
+          (statements
+            (switch_statement
+              (tuple_expression
+                (simple_identifier)
+                (simple_identifier))
+              (switch_entry
+                (switch_pattern
+                  (pattern
+                    (pattern
+                      (simple_identifier)
+                      (pattern
+                        (value_binding_pattern)
+                        (simple_identifier)))
+                    (pattern
+                      (simple_identifier)
+                      (pattern
+                        (value_binding_pattern)
+                        (simple_identifier)))))
+                (statements
+                  (control_transfer_statement
+                    (equality_expression
+                      (simple_identifier)
+                      (simple_identifier)))))
+              (switch_entry
+                (default_keyword)
+                (statements
+                  (control_transfer_statement
+                    (boolean_literal)))))))))))


### PR DESCRIPTION
This adds new rules for parameter packs and expansions in both type and expression position. Since this includes the keyword "repeat", which was already a keyword for a do-while loop, we must modify the do-while loop rule so that it remains valid long enough to disqualify the parameter-pack interpretation.

With this change, it's starting to look like the "contextual keyword that is special cased as an identifier" pattern is going to become more standard. To facilitate that, this creates an explicit (hidden) rule for it.

Fixes #381
