### PR TITLE
Revert "Loosen tree-sitter dependency versions"

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,11 +20,10 @@ include = [
 path = "bindings/rust/lib.rs"
 
 [dependencies]
-tree-sitter = ">=0.20.4, <0.23.0"
+tree-sitter = "^0.20.4"
 
 [build-dependencies]
 cc = "1.0"
 
 [dev-dependencies]
 anyhow = "1.0"
-tree-sitter = "0.20.4"


### PR DESCRIPTION
Reverts alex-pinkus/tree-sitter-swift#379

This leads to dependency resolution issues where two versions of `tree-sitter` end up in the binary -- see #386 