### PR TITLE
Update github actions for publish tasks

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,8 +14,8 @@ jobs:
       type: ${{ steps.npm_publish.outputs.type }}
       package_version: ${{ steps.npm_publish.outputs.version }}
     steps:
-      - uses: actions/checkout@v1
-      - uses: actions/setup-node@v1
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: 20
       - run: npm install

--- a/scripts/write-generated-grammar.sh
+++ b/scripts/write-generated-grammar.sh
@@ -6,7 +6,7 @@ ref=$1
 branch_name=with-generated-files
 
 # Load the branch that contains generated grammar files.
-git checkout $branch_name
+git checkout -b $branch_name -t origin/$branch_name
 
 # Update our local directory to match the $ref, but then put the HEAD back at the previous commit.
 # This will blow away the existing generated grammar. That's OK because this branch is only ever


### PR DESCRIPTION
Some tasks that only run on publish still need modernization -- since they didn't run on PR, the issues didn't come up until merge.
