### PR TITLE
Wait for tree-sitter from node-gyp

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -19,8 +19,17 @@
       ],
       "actions": [
           {
+	      "action_name": "wait_for_tree_sitter",
+	      "action": ["node", "scripts/wait-for-tree-sitter.js"],
+	      "inputs": [],
+	      "outputs": ["node_modules/tree-sitter-cli"]
+	  },
+          {
 	      "action_name": "generate_header_files",
-	      "inputs": ["grammar.js"],
+	      "inputs": [
+	          "grammar.js",
+		  "node_modules/tree-sitter-cli"
+	      ],
 	      "outputs": [
 	          "src/grammar.json",
 		  "src/node-types.json",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "prebuilds/**",
     "bindings/node/*",
     "queries/*",
+    "scripts/*",
     "src/**"
   ],
   "author": "Alex Pinkus <alex.pinkus@gmail.com>",


### PR DESCRIPTION
The tree-sitter executable gets downloaded as a binary during the
build, which is notably asynchronous -- this is why
`scripts/wait-for-tree-sitter.js` exists. The code in `binding.gyp`
therefore needs to run that before generating the header files.
