### PR TITLE
Outline implemented

### DIFF
--- a/queries/outline.scm
+++ b/queries/outline.scm
@@ -1,0 +1,50 @@
+(protocol_declaration
+    declaration_kind: "protocol" @name
+    .
+    _ * @name
+    .
+    body: (protocol_body)
+) @item
+
+(class_declaration
+    declaration_kind: (
+        [
+            "actor"
+            "class"
+            "extension"
+            "enum"
+            "struct"
+        ]
+    ) @name
+    .
+    _ * @name
+    .
+    body: (_)
+) @item
+
+(init_declaration
+    name: "init" @name
+    .
+    _ * @name
+    .
+    body: (function_body)
+) @item
+
+(deinit_declaration
+    "deinit" @name) @item
+
+(function_declaration
+    "func" @name
+    .
+    _ * @name
+    .
+    body: (function_body)
+) @item
+
+(class_body
+    (property_declaration
+        (value_binding_pattern) @name
+        name: (pattern) @name
+        (type_annotation)? @name
+    ) @item
+)

--- a/test/outline/outline.swift
+++ b/test/outline/outline.swift
@@ -1,0 +1,73 @@
+import Foundation
+
+protocol SomeProtocol {}
+protocol SomeProtocol<T>: Encodable, Decodable where T == Element {}
+
+public class SomeClass: Codable {
+
+    var somesss = 0
+    let another = 111
+    var sieee: Int = 11
+    func some(zzz: String, xxx: Int) {}
+    public func some(sommm: Int, _ another: String) {
+
+    }
+
+    public func somess<T, V>(_ sss: T, xxx: V) -> V? {}
+    public func somess<T, V>(_ sss: T, xxx: V) -> V {}
+    func some(_ completion: @escaping ((String) -> Void)) {
+    }
+    func anotherFucn() -> (String, Int) {}
+    func anotherFucn() -> [String: Int] {}
+    func anotherFucxn() -> [String] {}
+    func anotherFucn() -> Set<String> {}
+    func anotherFucn() -> [String] {}
+    func anotherFucn() async -> [String] {}
+    func anotherFucn() throws -> [String] {}
+    func anotherFucn() async throws -> [String] {}
+}
+
+func someExternalFunc() {}
+
+extension SomeProtocol: Encodable, Decodable {}
+
+actor SomeActor {
+    var goodVar = 11
+    func somssssse() {}
+    func some(x: Int, _ y: String) -> String? {
+        var wrongVar = 111
+    }
+
+    func llll() -> String { "" }
+    init(_ vars: String) {}
+    deinit {}
+}
+
+class SomeClass<T, V>: Codable where T: Decodable, V: Encodable {
+    struct SomeAnother {
+        init() {
+
+        }
+    }
+    init<T, V>(_ sss: T, xxx: V) {
+
+    }
+}
+
+// TODO: Some stuff
+// FIXME: Some fix
+// MARK: Some mark
+
+struct SomeAAA {
+    struct SomeBBBB {
+        let ppppp: Int?
+    }
+    enum Some {
+        case some
+    }
+    var xxxx: String?
+}
+
+//extension SomeAAA.SomeBBBB { // breaks breadcrumbs
+//    var someVariable: String { "" }
+//}


### PR DESCRIPTION
`outline.scm` file added.

It handles declarations of 
- `protocol`, 
- `actor`, 
- `class`, 
- `struct`, 
- `enum`
- `extension`
- `func` (both global and methods)
- type properties

In sake of performance and simplicity it captures the whole line from whatever `keyword` till `*_body`.

Verbosity in functions and types symbols made by purpose, in sake of simplicity and performance (every time i tried to make capture more precise in function especially ended up 60 sec warmup of zed on those grammars.