### PR TITLE
Code cleanup

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
   "scripts": {
     "install": "node-gyp-build",
     "postinstall": "node-gyp configure && node-gyp build",
-    "build": "npx tree-sitter-cli generate --no-bindings",
-    "build-wasm": "npx tree-sitter-cli build --wasm",
+    "build": "tree-sitter generate --no-bindings",
+    "build-wasm": "tree-sitter build --wasm",
     "ci": "prettier --check grammar.js",
     "test-ci": "./scripts/test-with-memcheck.sh --install-valgrind",
     "test": "./scripts/test-with-memcheck.sh",


### PR DESCRIPTION
This is a little cleanup. I learned that NPM puts binaries from dev dependencies on the path automatically when running scripts. Therefore, the explicit call to npx is not necessary in the scripts in package.json. Apologies for the churn!
