### PR TITLE
Add `tree-sitter.json` for compatibility with newer versions of tree-sitter

### DIFF
--- a/tree-sitter.json
+++ b/tree-sitter.json
@@ -1,0 +1,39 @@
+{
+  "grammars": [
+    {
+      "name": "swift",
+      "camelcase": "Swift",
+      "scope": "source.swift",
+      "path": ".",
+      "file-types": [
+        "swift"
+      ],
+      "highlights": "queries/highlights.scm",
+      "injections": "queries/injections.scm",
+      "locals": "queries/locals.scm",
+      "injection-regex": "swift"
+    }
+  ],
+  "metadata": {
+    "version": "0.6.0",
+    "license": "MIT",
+    "description": "A tree-sitter grammar for the Swift programming language.",
+    "authors": [
+      {
+        "name": "Alex Pinkus",
+        "email": "alex.pinkus@gmail.com"
+      }
+    ],
+    "links": {
+      "repository": "git+https://github.com/alex-pinkus/tree-sitter-swift.git"
+    }
+  },
+  "bindings": {
+    "c": true,
+    "go": true,
+    "node": true,
+    "python": true,
+    "rust": true,
+    "swift": true
+  }
+}


### PR DESCRIPTION
Hi @alex-pinkus, thanks for the amazing work!

I've noticed that newer versions of tree-sitter (I'm currently using 0.24.2) [require a `tree-sitter.json` file](https://tree-sitter.github.io/tree-sitter/creating-parsers#command-init) in the root directory, instead of specifying settings under the `tree-sitter` key in `package.json`. While running `tree-sitter generate` automatically migrates to the config file, using this grammar as a npm dependency fails because the `tree-sitter.json` file is expected to be present.

This PR adds the `tree-sitter.json` config file. I’ve kept the `tree-sitter` key in `package.json` for backwards compatibility with older versions.