### PR TITLE
Update version of upload-artifact action in workflow

### DIFF
--- a/.github/workflows/parser-src.yml
+++ b/.github/workflows/parser-src.yml
@@ -17,7 +17,7 @@ jobs:
       - run: npm install
       - run: npm run test-ci
       - name: Publish parser source
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: generated-parser-src
           path: src


### PR DESCRIPTION
This PR fixes the GitHub Actions workflow that publishes the grammar.json and parser.c files. The `actions/upload-artifact@v2` action is deprecated, which is causing the workflow to fail. This update bumps the action version to v4, which should resolve the issue and make it run again.