### PR TITLE
Update go.mod to use the correct GitHub link

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/tree-sitter/tree-sitter-swift
+module github.com/alex-pinkus/tree-sitter-swift
 
 go 1.23
 


### PR DESCRIPTION
See #451 