### PR TITLE
Add support for hex real literals

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -71,6 +71,7 @@ const HEX_DIGITS = token(sep1(/[0-9a-fA-F]+/, /_+/));
 const OCT_DIGITS = token(sep1(/[0-7]+/, /_+/));
 const BIN_DIGITS = token(sep1(/[01]+/, /_+/));
 const REAL_EXPONENT = token(seq(/[eE]/, optional(/[+-]/), DEC_DIGITS));
+const HEX_REAL_EXPONENT = token(seq(/[pP]/, optional(/[+-]/), DEC_DIGITS));
 
 var LEXICAL_IDENTIFIER;
 
@@ -293,12 +294,17 @@ module.exports = grammar({
         $.regex_literal,
         "nil"
       ),
-    // TODO: Hex exponents
     real_literal: ($) =>
       token(
         choice(
           seq(DEC_DIGITS, REAL_EXPONENT),
-          seq(optional(DEC_DIGITS), ".", DEC_DIGITS, optional(REAL_EXPONENT))
+          seq(optional(DEC_DIGITS), ".", DEC_DIGITS, optional(REAL_EXPONENT)),
+          seq(
+            "0x",
+            HEX_DIGITS,
+            optional(seq(".", HEX_DIGITS)),
+            HEX_REAL_EXPONENT
+          )
         )
       ),
     integer_literal: ($) => token(seq(optional(/[1-9]/), DEC_DIGITS)),

--- a/test/corpus/literals.txt
+++ b/test/corpus/literals.txt
@@ -146,6 +146,7 @@ Real literals
 1e-10
 4.3
 +53.9e-3
+0x1.921F_B600p1
 
 --------------------------------------------------------------------------------
 
@@ -156,7 +157,8 @@ Real literals
   (real_literal)
   (real_literal)
   (prefix_expression
-    (real_literal)))
+    (real_literal))
+  (real_literal))
 
 ================================================================================
 Collections


### PR DESCRIPTION
Swift supports [hexadecimal floating-point literals](https://docs.swift.org/swift-book/documentation/the-swift-programming-language/lexicalstructure/#Floating-Point-Literals). This PR adds support for them.

E.g.

```swift
0x1.921F_B544_42D1_8000p1 == 3.141592_653589_7932
```