### PR TITLE
Update `tree-sitter` peer dependency and `tree-sitter-cli` dependency.

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ To use this from NPM, you'll add similar dependencies to `package.json`:
 ```
 "dependencies: {
   "tree-sitter-swift": "0.6.0",
-  "tree-sitter": "^0.21.1"
+  "tree-sitter": "^0.22.1"
 }
 ```
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "prettier": "2.3.2"
       },
       "peerDependencies": {
-        "tree-sitter": "^0.21.1"
+        "tree-sitter": "^0.22.1"
       },
       "peerDependenciesMeta": {
         "tree_sitter": {

--- a/package.json
+++ b/package.json
@@ -52,11 +52,11 @@
   "dependencies": {
     "node-addon-api": "^8.0.0",
     "node-gyp-build": "^4.8.0",
-    "tree-sitter-cli": "^0.23",
+    "tree-sitter-cli": "^0.23.4",
     "which": "2.0.2"
   },
   "peerDependencies": {
-    "tree-sitter": "^0.21.1"
+    "tree-sitter": "^0.22.1"
   },
   "peerDependenciesMeta": {
     "tree_sitter": {

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
   "dependencies": {
     "node-addon-api": "^8.0.0",
     "node-gyp-build": "^4.8.0",
-    "tree-sitter-cli": "^0.23.4",
+    "tree-sitter-cli": "^0.24.5",
     "which": "2.0.2"
   },
   "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
   "dependencies": {
     "node-addon-api": "^8.0.0",
     "node-gyp-build": "^4.8.0",
-    "tree-sitter-cli": "^0.24.5",
+    "tree-sitter-cli": "^0.23",
     "which": "2.0.2"
   },
   "peerDependencies": {

--- a/test-npm-package/package-lock.json
+++ b/test-npm-package/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "tree-sitter": "^0.21.1",
+        "tree-sitter": "^0.22.1",
         "tree-sitter-swift": "file:../"
       }
     },
@@ -29,7 +29,7 @@
         "prettier": "2.3.2"
       },
       "peerDependencies": {
-        "tree-sitter": "^0.21.1"
+        "tree-sitter": "^0.22.1"
       },
       "peerDependenciesMeta": {
         "tree_sitter": {

--- a/test-npm-package/package.json
+++ b/test-npm-package/package.json
@@ -9,7 +9,7 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "tree-sitter": "^0.21.1",
+    "tree-sitter": "^0.22.1",
     "tree-sitter-swift": "file:../"
   }
 }


### PR DESCRIPTION
> This is a draft PR until I or the maintainers can test it.

This PR updates `tree-sitter-cli` and `tree-sitter` to match the versions in `tree-sitter-obj`.