### PR TITLE
Add support for suppressed copyable constraints

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -416,7 +416,8 @@ module.exports = grammar({
           $.existential_type,
           $.protocol_composition_type,
           $.type_parameter_pack,
-          $.type_pack_expansion
+          $.type_pack_expansion,
+          $.suppressed_constraint
         )
       ),
     // The grammar just calls this whole thing a `type-identifier` but that's a bit confusing.
@@ -487,6 +488,9 @@ module.exports = grammar({
           repeat1(seq("&", prec.right($._unannotated_type)))
         )
       ),
+    suppressed_constraint: ($) =>
+      prec.right(seq("~", field("suppressed", $.suppressed_constraint_type))),
+    suppressed_constraint_type: ($) => "Copyable",
     ////////////////////////////////
     // Expressions - https://docs.swift.org/swift-book/ReferenceManual/Expressions.html
     ////////////////////////////////
@@ -1507,7 +1511,12 @@ module.exports = grammar({
     _inheritance_specifiers: ($) =>
       prec.left(sep1($._annotated_inheritance_specifier, choice(",", "&"))),
     inheritance_specifier: ($) =>
-      prec.left(field("inherits_from", choice($.user_type, $.function_type))),
+      prec.left(
+        field(
+          "inherits_from",
+          choice($.user_type, $.function_type, $.suppressed_constraint)
+        )
+      ),
     _annotated_inheritance_specifier: ($) =>
       seq(repeat($.attribute), $.inheritance_specifier),
     type_parameters: ($) =>

--- a/grammar.js
+++ b/grammar.js
@@ -489,8 +489,12 @@ module.exports = grammar({
         )
       ),
     suppressed_constraint: ($) =>
-      prec.right(seq("~", field("suppressed", $.suppressed_constraint_type))),
-    suppressed_constraint_type: ($) => "Copyable",
+      prec.right(
+        seq(
+          "~",
+          field("suppressed", alias($.simple_identifier, $.type_identifier))
+        )
+      ),
     ////////////////////////////////
     // Expressions - https://docs.swift.org/swift-book/ReferenceManual/Expressions.html
     ////////////////////////////////

--- a/package-lock.json
+++ b/package-lock.json
@@ -807,9 +807,10 @@
       }
     },
     "node_modules/node-addon-api": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.0.0.tgz",
-      "integrity": "sha512-ipO7rsHEBqa9STO5C5T10fj732ml+5kLN1cAG8/jdHd56ldQeGj3Q7+scUS+VHK/qy1zLEwC4wMK5+yM0btPvw==",
+      "version": "8.3.1",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.3.1.tgz",
+      "integrity": "sha512-lytcDEdxKjGJPTLEfW4mYMigRezMlyJY8W4wxJK8zE533Jlb8L8dRuObJFWg2P+AuOIxoCgKF+2Oq4d4Zd0OUA==",
+      "license": "MIT",
       "engines": {
         "node": "^18 || ^20 || >= 21"
       }
@@ -839,9 +840,10 @@
       }
     },
     "node_modules/node-gyp-build": {
-      "version": "4.8.0",
-      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.0.tgz",
-      "integrity": "sha512-u6fs2AEUljNho3EYTJNBfImO5QTo/J/1Etd+NVdCj7qWKUSN/bSLkZwhDv7I+w/MSC6qJ4cknepkAYykDdK8og==",
+      "version": "4.8.4",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
+      "integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
+      "license": "MIT",
       "bin": {
         "node-gyp-build": "bin.js",
         "node-gyp-build-optional": "optional.js",
@@ -1366,15 +1368,15 @@
       }
     },
     "node_modules/tree-sitter": {
-      "version": "0.21.1",
-      "resolved": "https://registry.npmjs.org/tree-sitter/-/tree-sitter-0.21.1.tgz",
-      "integrity": "sha512-7dxoA6kYvtgWw80265MyqJlkRl4yawIjO7S5MigytjELkX43fV2WsAXzsNfO7sBpPPCF5Gp0+XzHk0DwLCq3xQ==",
+      "version": "0.22.4",
+      "resolved": "https://registry.npmjs.org/tree-sitter/-/tree-sitter-0.22.4.tgz",
+      "integrity": "sha512-usbHZP9/oxNsUY65MQUsduGRqDHQOou1cagUSwjhoSYAmSahjQDAVsh9s+SlZkn8X8+O1FULRGwHu7AFP3kjzg==",
       "hasInstallScript": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "node-addon-api": "^8.0.0",
-        "node-gyp-build": "^4.8.0"
+        "node-addon-api": "^8.3.0",
+        "node-gyp-build": "^4.8.4"
       }
     },
     "node_modules/tree-sitter-cli": {
@@ -2121,9 +2123,9 @@
       }
     },
     "node-addon-api": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.0.0.tgz",
-      "integrity": "sha512-ipO7rsHEBqa9STO5C5T10fj732ml+5kLN1cAG8/jdHd56ldQeGj3Q7+scUS+VHK/qy1zLEwC4wMK5+yM0btPvw=="
+      "version": "8.3.1",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.3.1.tgz",
+      "integrity": "sha512-lytcDEdxKjGJPTLEfW4mYMigRezMlyJY8W4wxJK8zE533Jlb8L8dRuObJFWg2P+AuOIxoCgKF+2Oq4d4Zd0OUA=="
     },
     "node-gyp": {
       "version": "10.0.1",
@@ -2161,9 +2163,9 @@
       }
     },
     "node-gyp-build": {
-      "version": "4.8.0",
-      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.0.tgz",
-      "integrity": "sha512-u6fs2AEUljNho3EYTJNBfImO5QTo/J/1Etd+NVdCj7qWKUSN/bSLkZwhDv7I+w/MSC6qJ4cknepkAYykDdK8og=="
+      "version": "4.8.4",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
+      "integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ=="
     },
     "nopt": {
       "version": "7.2.0",
@@ -2533,13 +2535,13 @@
       }
     },
     "tree-sitter": {
-      "version": "0.21.1",
-      "resolved": "https://registry.npmjs.org/tree-sitter/-/tree-sitter-0.21.1.tgz",
-      "integrity": "sha512-7dxoA6kYvtgWw80265MyqJlkRl4yawIjO7S5MigytjELkX43fV2WsAXzsNfO7sBpPPCF5Gp0+XzHk0DwLCq3xQ==",
+      "version": "0.22.4",
+      "resolved": "https://registry.npmjs.org/tree-sitter/-/tree-sitter-0.22.4.tgz",
+      "integrity": "sha512-usbHZP9/oxNsUY65MQUsduGRqDHQOou1cagUSwjhoSYAmSahjQDAVsh9s+SlZkn8X8+O1FULRGwHu7AFP3kjzg==",
       "peer": true,
       "requires": {
-        "node-addon-api": "^8.0.0",
-        "node-gyp-build": "^4.8.0"
+        "node-addon-api": "^8.3.0",
+        "node-gyp-build": "^4.8.4"
       }
     },
     "tree-sitter-cli": {

--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -53,6 +53,8 @@
 (opaque_type ["some" @keyword])
 (existential_type ["any" @keyword])
 
+(suppressed_constraint (suppressed_constraint_type) @type)
+
 (precedence_group_declaration
  ["precedencegroup" @keyword]
  (simple_identifier) @type)

--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -53,8 +53,6 @@
 (opaque_type ["some" @keyword])
 (existential_type ["any" @keyword])
 
-(suppressed_constraint (suppressed_constraint_type) @type)
-
 (precedence_group_declaration
  ["precedencegroup" @keyword]
  (simple_identifier) @type)

--- a/test/corpus/classes.txt
+++ b/test/corpus/classes.txt
@@ -1704,10 +1704,10 @@ struct Foo<T: ~Copyable>: ~Copyable {
       (type_parameter
         (type_identifier)
         (suppressed_constraint
-          (suppressed_constraint_type))))
+          (type_identifier))))
     (inheritance_specifier
       (suppressed_constraint
-        (suppressed_constraint_type)))
+        (type_identifier)))
     (class_body
       (property_declaration
         (value_binding_pattern)

--- a/test/corpus/classes.txt
+++ b/test/corpus/classes.txt
@@ -1686,3 +1686,33 @@ distributed actor A {
           (property_modifier))
         (simple_identifier)
         (function_body)))))
+
+================================================================================
+Noncopyable struct
+================================================================================
+
+struct Foo<T: ~Copyable>: ~Copyable {
+    let bar: T
+}
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (class_declaration
+    (type_identifier)
+    (type_parameters
+      (type_parameter
+        (type_identifier)
+        (suppressed_constraint
+          (suppressed_constraint_type))))
+    (inheritance_specifier
+      (suppressed_constraint
+        (suppressed_constraint_type)))
+    (class_body
+      (property_declaration
+        (value_binding_pattern)
+        (pattern
+          (simple_identifier))
+        (type_annotation
+          (user_type
+            (type_identifier)))))))


### PR DESCRIPTION
Add support for parsing code like this:

```swift
struct Foo<T: ~Copyable>: ~Copyable {
    let bar: T
}
```