### PR TITLE
Add support for freestanding macros

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,1 +1,3 @@
-{}
+{
+    "trailingComma": "es5"
+}

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -128,17 +128,17 @@ const uint64_t OP_SYMBOL_SUPPRESSOR[OPERATOR_COUNT] = {
     0, // EQ_EQ,
     0, // PLUS_THEN_WS,
     0, // MINUS_THEN_WS,
-    1 << FAKE_TRY_BANG, // BANG,
-      0, // THROWS_KEYWORD,
-      0, // RETHROWS_KEYWORD,
-      0, // DEFAULT_KEYWORD,
-      0, // WHERE_KEYWORD,
-      0, // ELSE_KEYWORD,
-      0, // CATCH_KEYWORD,
-      0, // AS_KEYWORD,
-      0, // AS_QUEST,
-      0, // AS_BANG,
-      0, // ASYNC_KEYWORD
+    1UL << FAKE_TRY_BANG, // BANG,
+        0, // THROWS_KEYWORD,
+        0, // RETHROWS_KEYWORD,
+        0, // DEFAULT_KEYWORD,
+        0, // WHERE_KEYWORD,
+        0, // ELSE_KEYWORD,
+        0, // CATCH_KEYWORD,
+        0, // AS_KEYWORD,
+        0, // AS_QUEST,
+        0, // AS_BANG,
+        0, // ASYNC_KEYWORD
 };
 
 #define RESERVED_OP_COUNT 31
@@ -717,12 +717,7 @@ const enum TokenType DIRECTIVE_SYMBOLS[DIRECTIVE_COUNT] = {
     DIRECTIVE_ENDIF
 };
 
-static uint8_t find_possible_compiler_directive(
-    struct ScannerState *state,
-    TSLexer *lexer,
-    const bool *valid_symbols,
-    enum TokenType *symbol_result
-) {
+static enum TokenType find_possible_compiler_directive(TSLexer *lexer) {
     bool possible_directives[DIRECTIVE_COUNT];
     for (int dir_idx = 0; dir_idx < DIRECTIVE_COUNT; dir_idx++) {
         possible_directives[dir_idx] = true;
@@ -795,9 +790,7 @@ static bool eat_raw_str_part(
             advance(lexer);
         } else if (hash_count == 1) {
             lexer->mark_end(lexer);
-            *symbol_result = find_possible_compiler_directive(
-                                 state, lexer, valid_symbols, symbol_result
-                             );
+            *symbol_result = find_possible_compiler_directive(lexer);
             return true;
         } else {
             return false;

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -2,7 +2,7 @@
 #include <string.h>
 #include <wctype.h>
 
-#define TOKEN_COUNT 28
+#define TOKEN_COUNT 33
 
 enum TokenType {
     BLOCK_COMMENT,
@@ -32,6 +32,11 @@ enum TokenType {
     AS_BANG,
     ASYNC_KEYWORD,
     CUSTOM_OPERATOR,
+    HASH_SYMBOL,
+    DIRECTIVE_IF,
+    DIRECTIVE_ELSEIF,
+    DIRECTIVE_ELSE,
+    DIRECTIVE_ENDIF,
     FAKE_TRY_BANG
 };
 
@@ -172,7 +177,7 @@ const char* RESERVED_OPS[RESERVED_OP_COUNT] = {
     "..<"
 };
 
-bool is_cross_semi_token(enum TokenType op) {
+static bool is_cross_semi_token(enum TokenType op) {
     switch(op) {
     case ARROW_OPERATOR:
     case DOT_OPERATOR:
@@ -697,6 +702,75 @@ static enum ParseDirective eat_whitespace(
     return CONTINUE_PARSING_NOTHING_FOUND;
 }
 
+#define DIRECTIVE_COUNT 4
+const char* DIRECTIVES[OPERATOR_COUNT] = {
+    "if",
+    "elseif",
+    "else",
+    "endif"
+};
+
+const enum TokenType DIRECTIVE_SYMBOLS[DIRECTIVE_COUNT] = {
+    DIRECTIVE_IF,
+    DIRECTIVE_ELSEIF,
+    DIRECTIVE_ELSE,
+    DIRECTIVE_ENDIF
+};
+
+static uint8_t find_possible_compiler_directive(
+    struct ScannerState *state,
+    TSLexer *lexer,
+    const bool *valid_symbols,
+    enum TokenType *symbol_result
+) {
+    bool possible_directives[DIRECTIVE_COUNT];
+    for (int dir_idx = 0; dir_idx < DIRECTIVE_COUNT; dir_idx++) {
+        possible_directives[dir_idx] = true;
+    }
+
+    int32_t str_idx = 0;
+    int32_t full_match = -1;
+    while(true) {
+        for (int dir_idx = 0; dir_idx < DIRECTIVE_COUNT; dir_idx++) {
+            if (!possible_directives[dir_idx]) {
+                continue;
+            }
+
+            uint8_t expected_char = DIRECTIVES[dir_idx][str_idx];
+            if (expected_char == '\0') {
+                full_match = dir_idx;
+                lexer->mark_end(lexer);
+            }
+
+            if (expected_char != lexer->lookahead) {
+                possible_directives[dir_idx] = false;
+                continue;
+            }
+        }
+
+        uint8_t match_count = 0;
+        for (int dir_idx = 0; dir_idx < DIRECTIVE_COUNT; dir_idx += 1) {
+            if (possible_directives[dir_idx]) {
+                match_count += 1;
+            }
+        }
+
+        if (match_count == 0) {
+            break;
+        }
+
+        lexer->advance(lexer, false);
+        str_idx += 1;
+    }
+
+    if (full_match == -1) {
+        // No compiler directive found, so just match the starting symbol
+        return HASH_SYMBOL;
+    }
+
+    return DIRECTIVE_SYMBOLS[full_match];
+}
+
 static bool eat_raw_str_part(
     struct ScannerState *state,
     TSLexer *lexer,
@@ -719,6 +793,12 @@ static bool eat_raw_str_part(
 
         if (lexer->lookahead == '"') {
             advance(lexer);
+        } else if (hash_count == 1) {
+            lexer->mark_end(lexer);
+            *symbol_result = find_possible_compiler_directive(
+                                 state, lexer, valid_symbols, symbol_result
+                             );
+            return true;
         } else {
             return false;
         }

--- a/test/corpus/literals.txt
+++ b/test/corpus/literals.txt
@@ -281,7 +281,7 @@ let _ = #"Foo"
     (pattern
       (wildcard_pattern))
     (ERROR
-      (UNEXPECTED '"'))
+      (UNEXPECTED '#'))
     (line_string_literal
       (line_str_text))))
 

--- a/test/corpus/macros.txt
+++ b/test/corpus/macros.txt
@@ -1,0 +1,124 @@
+================================================================================
+Basic macro invocation
+================================================================================
+
+#expect(true)
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (macro_invocation
+    (simple_identifier)
+    (call_suffix
+      (value_arguments
+        (value_argument
+          (boolean_literal))))))
+
+===
+SwiftUI Preview
+===
+
+#Preview {
+    VStack {
+        Text("Hello, world!")
+    }
+    .padding()
+}
+
+---
+
+(source_file
+  (macro_invocation
+    (simple_identifier)
+    (call_suffix
+      (lambda_literal
+        (statements
+          (call_expression
+            (navigation_expression
+              (call_expression
+                (simple_identifier)
+                (call_suffix
+                  (lambda_literal
+                    (statements
+                      (call_expression
+                        (simple_identifier)
+                        (call_suffix
+                          (value_arguments
+                            (value_argument
+                              (line_string_literal
+                                (line_str_text))))))))))
+              (navigation_suffix
+                (simple_identifier)))
+            (call_suffix
+              (value_arguments))))))))
+
+===
+Named SwiftUI Preview
+===
+
+#Preview("other") {
+    Text("Hello, world!")
+}
+
+---
+
+(source_file
+  (macro_invocation
+    (simple_identifier)
+    (call_suffix
+      (value_arguments
+        (value_argument
+          (line_string_literal
+            (line_str_text))))
+      (lambda_literal
+        (statements
+          (call_expression
+            (simple_identifier)
+            (call_suffix
+              (value_arguments
+                (value_argument
+                  (line_string_literal
+                    (line_str_text)))))))))))
+
+===
+Predicate macro
+===
+
+let messagePredicate = #Predicate<Message> { message in
+    message.length < 100 && message.sender == "Jeremy"
+}
+
+---
+
+(source_file
+  (property_declaration
+    (value_binding_pattern)
+    (pattern
+      (simple_identifier))
+    (macro_invocation
+      (simple_identifier)
+      (type_parameters
+        (type_parameter
+          (type_identifier)))
+      (call_suffix
+        (lambda_literal
+          (lambda_function_type
+            (lambda_function_type_parameters
+              (lambda_parameter
+                (simple_identifier))))
+          (statements
+            (comparison_expression
+              (navigation_expression
+                (simple_identifier)
+                (navigation_suffix
+                  (simple_identifier)))
+              (conjunction_expression
+                (integer_literal)
+                (equality_expression
+                  (navigation_expression
+                    (simple_identifier)
+                    (navigation_suffix
+                      (simple_identifier)))
+                  (line_string_literal
+                    (line_str_text)))))))))))
+

--- a/test/corpus/statements.txt
+++ b/test/corpus/statements.txt
@@ -445,8 +445,8 @@ do {
 } catch let error as MyError {
 } catch SomeError.specificError {
 } catch let error as MyOtherError where error.code == 2 {
-} catch let MyEnumError.missingField(fieldName) { 
-} catch MyEnumError.missingField(fieldName: let fieldName) { 
+} catch let MyEnumError.missingField(fieldName) {
+} catch MyEnumError.missingField(fieldName: let fieldName) {
 } catch {
 }
 
@@ -1058,12 +1058,47 @@ Compiler diagnostics
 --------------------------------------------------------------------------------
 
 (source_file
-  (directive)
+  (directive
+    (simple_identifier))
+  (diagnostic)
+  (directive
+    (simple_identifier))
   (diagnostic)
   (directive)
   (diagnostic)
+  (directive))
+
+===
+Platform compilation conditions
+===
+
+#if os(OSX) || os(Linux)
+print("yes")
+#else
+print("no")
+#endif
+
+---
+
+(source_file
+  (directive
+    (simple_identifier)
+    (simple_identifier))
+  (call_expression
+    (simple_identifier)
+    (call_suffix
+      (value_arguments
+        (value_argument
+          (line_string_literal
+            (line_str_text))))))
   (directive)
-  (directive)
+  (call_expression
+    (simple_identifier)
+    (call_suffix
+      (value_arguments
+        (value_argument
+          (line_string_literal
+            (line_str_text))))))
   (directive))
 
 ================================================================================
@@ -1115,7 +1150,7 @@ actor.increment()
 ================================================================================
 
 extension LottieLoopMode: Equatable {
-  public static func == (lhs: LottieLoopMode, rhs: LottieLoopMode) -> Bool {   
+  public static func == (lhs: LottieLoopMode, rhs: LottieLoopMode) -> Bool {
     switch (lhs, rhs) {
     case (.repeat(let lhsAmount), .repeat(let rhsAmount)):
       return lhsAmount == rhsAmount

--- a/test/highlight/AppDelegate.swift
+++ b/test/highlight/AppDelegate.swift
@@ -19,8 +19,6 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         _ = try! DatabaseQueue()
 //        ^ operator
 //          ^ keyword
-//             ^ operator
-//               ^ function.call
         _ = FTS5()
         _ = sqlite3_preupdate_new(nil, 0, nil)
 //                                ^ variable.builtin


### PR DESCRIPTION
Fixes #438

This is _conceptually_ a one liner, just adding a `macro_invocation` rule. However, it's made more complicated because of existing use of the `#` symbol (regex/string literals, and directives/diagnostics).

Previously, with the former usage occupying expression position and the latter usage in extras with custom token precedence, we could get away with using the external scanner for only some of them. However, this new usage has caused the worlds to collide.

The initial fix for that is easy -- unify all of the actual `#` symbols to [Ca new external-scanner token we emit when we see one `#` and not a string after it. However, that causes issues with directives because of their custom token precedence (which cannot be combined with external scanners). We thus need to parse the directive condition in C and emit it as standalone. Then we need to parse the rest of the condition more precisely than before.
