### PR TITLE
fix: go pindings

### DIFF
--- a/bindings/go/binding.go
+++ b/bindings/go/binding.go
@@ -1,7 +1,6 @@
 package tree_sitter_swift
 
 // #cgo CFLAGS: -std=c11 -fPIC
-// #include "../../src/parser.c"
 // #include "../../src/scanner.c"
 import "C"
 

--- a/bindings/go/binding_test.go
+++ b/bindings/go/binding_test.go
@@ -3,8 +3,8 @@ package tree_sitter_swift_test
 import (
 	"testing"
 
+	tree_sitter_swift "github.com/alex-pinkus/tree-sitter-swift/bindings/go"
 	tree_sitter "github.com/tree-sitter/go-tree-sitter"
-	tree_sitter_swift "github.com/tree-sitter/tree-sitter-swift/bindings/go"
 )
 
 func TestCanLoadGrammar(t *testing.T) {


### PR DESCRIPTION
Issues with the Go bindings:
- You include `parser.c` which doesn't exist
- You did not change the module name from the template
- Go compiler can't find `tree_sitter/parser.h`

Do you expect `tree_sitter` to be available as an installed library?

```
# github.com/alex-pinkus/tree-sitter-swift/bindings/go
In file included from ../tree-sitter-swift/bindings/go/binding.go:4:
./../../src/scanner.c:1:10: fatal error: 'tree_sitter/parser.h' file not found
    1 | #include "tree_sitter/parser.h"
      |          ^~~~~~~~~~~~~~~~~~~~~~
1 error generated.
```