### PR TITLE
Expand trailing comma support

### DIFF
--- a/test/corpus/functions.txt
+++ b/test/corpus/functions.txt
@@ -243,7 +243,7 @@ Operator overrides
 ================================================================================
 
 public static func < (lhs: Wrapped<F>, rhs: Wrapped<F>) -> Bool {
-    return false 
+    return false
 }
 
 public func ??<V : Value>(optional: Expression<V?>, defaultValue: V) -> Expression<V> {
@@ -1376,3 +1376,114 @@ func makePairs<each First, each Second>(
                   (value_argument
                     (value_parameter_pack
                       (simple_identifier))))))))))))
+
+===
+Parameter lists with trailing commas
+===
+
+foo(
+  1,
+)
+
+foo(
+  1,
+  2,
+  3,
+)
+
+---
+
+(source_file
+  (call_expression
+    (simple_identifier)
+    (call_suffix
+      (value_arguments
+        (value_argument
+          (integer_literal)))))
+  (call_expression
+    (simple_identifier)
+    (call_suffix
+      (value_arguments
+        (value_argument
+          (integer_literal))
+        (value_argument
+          (integer_literal))
+        (value_argument
+          (integer_literal))))))
+
+===
+Generic parameter lists with trailing commas
+===
+
+f<
+  X,
+>()
+
+f<
+  X,
+  Y,
+  Z,
+>()
+
+---
+
+(source_file
+  (constructor_expression
+    (user_type
+      (type_identifier)
+      (type_arguments
+        (user_type
+          (type_identifier))))
+    (constructor_suffix
+      (value_arguments)))
+  (constructor_expression
+    (user_type
+      (type_identifier)
+      (type_arguments
+        (user_type
+          (type_identifier))
+        (user_type
+          (type_identifier))
+        (user_type
+          (type_identifier))))
+    (constructor_suffix
+      (value_arguments))))
+
+===
+Closure capture lists with trailing commas
+===
+
+f = { [weak x,] in
+  // body
+}
+
+f = { [weak x, y, z,] in
+  // body
+}
+
+---
+
+(source_file
+  (assignment
+    (directly_assignable_expression
+      (simple_identifier))
+    (lambda_literal
+      (capture_list
+        (capture_list_item
+          (ownership_modifier)
+          (simple_identifier)))
+      (comment)))
+  (assignment
+    (directly_assignable_expression
+      (simple_identifier))
+    (lambda_literal
+      (capture_list
+        (capture_list_item
+          (ownership_modifier)
+          (simple_identifier))
+        (capture_list_item
+          (simple_identifier))
+        (capture_list_item
+          (simple_identifier)))
+      (comment))))
+

--- a/test/corpus/literals.txt
+++ b/test/corpus/literals.txt
@@ -761,3 +761,67 @@ doOperation(on: a, /)
           (simple_identifier))
         (value_argument))))
   (comment))
+
+===
+List with trailing comma
+===
+
+[
+  1,
+  2,
+  3,
+]
+
+---
+
+(source_file
+  (array_literal
+    element: (integer_literal)
+    element: (integer_literal)
+    element: (integer_literal)))
+
+===
+Tuples with trailing commas
+===
+
+(
+  1,
+)
+
+(
+  1,
+  2,
+  3,
+)
+
+---
+
+(source_file
+  (tuple_expression
+    (integer_literal))
+  (tuple_expression
+    (integer_literal)
+    (integer_literal)
+    (integer_literal)))
+
+===
+String interpolation with trailing commas
+===
+
+"\(1,)"
+
+"\(1, 2, 3,)"
+
+---
+
+(source_file
+  (line_string_literal
+    (interpolated_expression
+      (integer_literal)))
+  (line_string_literal
+    (interpolated_expression
+      (integer_literal))
+    (interpolated_expression
+      (integer_literal))
+    (interpolated_expression
+      (integer_literal))))


### PR DESCRIPTION
Fixes #486

Adds a new helper, `sep1Opt`, that allows the separator to optionally
occur at the end.

It would have been nice to just change the behavior of `sep1` (since
we are allowed to be more permissive than the actual grammar) but
that introduces some parsing ambiguities in cases with other
separators, like enums.
