### PR TITLE
Update setup.py to declare a license

### DIFF
--- a/scripts/write-generated-grammar.sh
+++ b/scripts/write-generated-grammar.sh
@@ -40,6 +40,7 @@ git add test
 git add queries
 git add Makefile
 git add bindings/c/*.in
+git add setup.py
 git commit -m "Updating grammar files for version ${ref/refs\/tags\//}"
 echo "Committing new generated grammar"
 

--- a/setup.py
+++ b/setup.py
@@ -54,5 +54,7 @@ setup(
         "build": Build,
         "bdist_wheel": BdistWheel
     },
+    license="MIT",
+    python_requires=">=3.8",
     zip_safe=False
 )


### PR DESCRIPTION
Most of the changes from #433 related to building from source, but
instead we're just going to publish from the generated-files branch.

However, the lines about `license` and `python_requires` seem useful
regardless. And if we're going to publish from that branch, we
should also sync this script to that branch.
