### PR TITLE
Include LICENSE file in crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ license = "MIT"
 
 build = "bindings/rust/build.rs"
 include = [
+  "LICENSE",
   "bindings/rust/*",
   "grammar.ts",
   "queries/*",


### PR DESCRIPTION
This is needed by the MIT license and required for packaging in distributions like Fedora

```
$ cargo package --allow-dirty --list | grep LICENSE
LICENSE
```