### PR TITLE
fix: calloc(0, ...) allocates zero bytes in scanner

### DIFF
--- a/src/scanner.c
+++ b/src/scanner.c
@@ -234,7 +234,7 @@ struct ScannerState {
 };
 
 void *tree_sitter_swift_external_scanner_create() {
-    return calloc(0, sizeof(struct ScannerState));
+    return calloc(1, sizeof(struct ScannerState));
 }
 
 void tree_sitter_swift_external_scanner_destroy(void *payload) {


### PR DESCRIPTION
## Summary

`tree_sitter_swift_external_scanner_create` calls `calloc(0, sizeof(struct ScannerState))` which allocates zero bytes. When `eat_raw_str_part` later reads `state->ongoing_raw_str_hash_count` (a `uint32_t`), it performs an invalid 4-byte read past the end of the zero-sized allocation.

**Fix:** change the first argument from `0` to `1` so that one `ScannerState` is properly allocated.

## Valgrind output

Found via valgrind (memcheck) when parsing certain Swift files:

```
Invalid read of size 4
   at eat_raw_str_part (scanner.c:775)
   by tree_sitter_swift_external_scanner_scan (scanner.c:921)
Address is 0 bytes after a block of size 0 alloc'd
   at calloc
   by tree_sitter_swift_external_scanner_create (scanner.c:237)
```

One-character fix: `calloc(0, ...)` → `calloc(1, ...)`.