### PR TITLE
Fix UB in eat_operators

### DIFF
--- a/src/scanner.c
+++ b/src/scanner.c
@@ -511,7 +511,7 @@ static bool eat_operators(
         uint64_t suppressing_symbols = OP_SYMBOL_SUPPRESSOR[full_match];
         if (suppressing_symbols) {
             for (uint64_t suppressor = 0; suppressor < TOKEN_COUNT; suppressor++) {
-                if (!(suppressing_symbols & 1 << suppressor)) {
+                if (!(suppressing_symbols & 1ULL << suppressor)) {
                     continue;
                 }
 


### PR DESCRIPTION
Fixes #558 

The literal 1 is a signed int (32 bits). When suppressor >= 31, the left shift is undefined behavior per C99/C11 §6.5.7. This swaps it out for 1ULL to ensure 64-bit unsigned shift.