### PR TITLE
Bump Python package version to 0.7.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "tree-sitter-swift"
 description = "Swift grammar for tree-sitter"
-version = "0.0.1"
+version = "0.7.1"
 keywords = ["incremental", "parsing", "tree-sitter", "swift"]
 classifiers = [
   "Intended Audience :: Developers",


### PR DESCRIPTION
The PyPI package has been stuck at 0.0.1 since initial publish, while the
  grammar is at 0.7.1. The existing `publish-pypi.yml` CI workflow builds and
  uploads on tag push, but PyPI rejects the upload because the version in
  `pyproject.toml` was never bumped to match the release tag.

  This one-line change unblocks the CI to publish the current grammar to PyPI,
  so `pip install tree-sitter-swift` gives users the up-to-date parser.

Related to #542 — unblocks PyPI publishing, though the pre-generated `parser.c`
  is still needed to fully eliminate the tree-sitter-cli build dependency.