### PR TITLE
Add typed throws (throws(E)) grammar support

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -466,7 +466,7 @@ module.exports = grammar({
       seq(
         field("params", choice($.tuple_type, $._unannotated_type)),
         optional($._async_keyword),
-        optional($.throws),
+        optional(choice($.throws_clause, $.throws)),
         $._arrow_operator,
         field("return_type", $._type)
       ),
@@ -998,7 +998,7 @@ module.exports = grammar({
             seq("(", optional($.lambda_function_type_parameters), ")")
           ),
           optional($._async_keyword),
-          optional($.throws),
+          optional(choice($.throws_clause, $.throws)),
           optional(
             seq(
               $._arrow_operator,
@@ -1471,7 +1471,7 @@ module.exports = grammar({
           optional($.type_parameters),
           $._function_value_parameters,
           optional($._async_keyword),
-          optional($.throws),
+          optional(choice($.throws_clause, $.throws)),
           optional(
             seq(
               $._arrow_operator,
@@ -1664,6 +1664,8 @@ module.exports = grammar({
     _async_keyword: ($) => alias($._async_keyword_custom, "async"),
     _async_modifier: ($) => token("async"),
     throws: ($) => choice($._throws_keyword, $._rethrows_keyword),
+    throws_clause: ($) =>
+      seq($._throws_keyword, "(", field("type", $._unannotated_type), ")"),
     enum_class_body: ($) =>
       seq("{", repeat(choice($.enum_entry, $._type_level_declaration)), "}"),
     enum_entry: ($) =>
@@ -1744,7 +1746,7 @@ module.exports = grammar({
           optional($.type_parameters),
           $._function_value_parameters,
           optional($._async_keyword),
-          optional($.throws),
+          optional(choice($.throws_clause, $.throws)),
           optional($.type_constraints),
           optional(field("body", $.function_body))
         )
@@ -1796,7 +1798,8 @@ module.exports = grammar({
       seq(optional($.mutation_modifier), "get", optional($._getter_effects)),
     setter_specifier: ($) => seq(optional($.mutation_modifier), "set"),
     modify_specifier: ($) => seq(optional($.mutation_modifier), "_modify"),
-    _getter_effects: ($) => repeat1(choice($._async_keyword, $.throws)),
+    _getter_effects: ($) =>
+      repeat1(choice($._async_keyword, $.throws_clause, $.throws)),
     operator_declaration: ($) =>
       seq(
         choice("prefix", "infix", "postfix"),

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -1553,8 +1553,17 @@
           "type": "CHOICE",
           "members": [
             {
-              "type": "SYMBOL",
-              "name": "throws"
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "throws_clause"
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "throws"
+                }
+              ]
             },
             {
               "type": "BLANK"
@@ -4248,8 +4257,17 @@
             "type": "CHOICE",
             "members": [
               {
-                "type": "SYMBOL",
-                "name": "throws"
+                "type": "CHOICE",
+                "members": [
+                  {
+                    "type": "SYMBOL",
+                    "name": "throws_clause"
+                  },
+                  {
+                    "type": "SYMBOL",
+                    "name": "throws"
+                  }
+                ]
               },
               {
                 "type": "BLANK"
@@ -6948,8 +6966,17 @@
             "type": "CHOICE",
             "members": [
               {
-                "type": "SYMBOL",
-                "name": "throws"
+                "type": "CHOICE",
+                "members": [
+                  {
+                    "type": "SYMBOL",
+                    "name": "throws_clause"
+                  },
+                  {
+                    "type": "SYMBOL",
+                    "name": "throws"
+                  }
+                ]
               },
               {
                 "type": "BLANK"
@@ -8323,6 +8350,31 @@
         }
       ]
     },
+    "throws_clause": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "_throws_keyword"
+        },
+        {
+          "type": "STRING",
+          "value": "("
+        },
+        {
+          "type": "FIELD",
+          "name": "type",
+          "content": {
+            "type": "SYMBOL",
+            "name": "_unannotated_type"
+          }
+        },
+        {
+          "type": "STRING",
+          "value": ")"
+        }
+      ]
+    },
     "enum_class_body": {
       "type": "SEQ",
       "members": [
@@ -8970,8 +9022,17 @@
             "type": "CHOICE",
             "members": [
               {
-                "type": "SYMBOL",
-                "name": "throws"
+                "type": "CHOICE",
+                "members": [
+                  {
+                    "type": "SYMBOL",
+                    "name": "throws_clause"
+                  },
+                  {
+                    "type": "SYMBOL",
+                    "name": "throws"
+                  }
+                ]
               },
               {
                 "type": "BLANK"
@@ -9366,6 +9427,10 @@
           {
             "type": "SYMBOL",
             "name": "_async_keyword"
+          },
+          {
+            "type": "SYMBOL",
+            "name": "throws_clause"
           },
           {
             "type": "SYMBOL",

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -12074,6 +12074,10 @@
           "named": true
         },
         {
+          "type": "throws_clause",
+          "named": true
+        },
+        {
           "type": "type_constraints",
           "named": true
         },
@@ -12279,6 +12283,10 @@
         {
           "type": "throws",
           "named": true
+        },
+        {
+          "type": "throws_clause",
+          "named": true
         }
       ]
     }
@@ -12297,6 +12305,10 @@
         },
         {
           "type": "throws",
+          "named": true
+        },
+        {
+          "type": "throws_clause",
           "named": true
         }
       ]
@@ -14763,6 +14775,10 @@
           "named": true
         },
         {
+          "type": "throws_clause",
+          "named": true
+        },
+        {
           "type": "type_constraints",
           "named": true
         },
@@ -15560,6 +15576,10 @@
         },
         {
           "type": "throws",
+          "named": true
+        },
+        {
+          "type": "throws_clause",
           "named": true
         }
       ]
@@ -22196,6 +22216,10 @@
           "named": true
         },
         {
+          "type": "throws_clause",
+          "named": true
+        },
+        {
           "type": "type_constraints",
           "named": true
         },
@@ -26617,6 +26641,70 @@
     "type": "throws",
     "named": true,
     "fields": {}
+  },
+  {
+    "type": "throws_clause",
+    "named": true,
+    "fields": {
+      "type": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "array_type",
+            "named": true
+          },
+          {
+            "type": "dictionary_type",
+            "named": true
+          },
+          {
+            "type": "existential_type",
+            "named": true
+          },
+          {
+            "type": "function_type",
+            "named": true
+          },
+          {
+            "type": "metatype",
+            "named": true
+          },
+          {
+            "type": "opaque_type",
+            "named": true
+          },
+          {
+            "type": "optional_type",
+            "named": true
+          },
+          {
+            "type": "protocol_composition_type",
+            "named": true
+          },
+          {
+            "type": "suppressed_constraint",
+            "named": true
+          },
+          {
+            "type": "tuple_type",
+            "named": true
+          },
+          {
+            "type": "type_pack_expansion",
+            "named": true
+          },
+          {
+            "type": "type_parameter_pack",
+            "named": true
+          },
+          {
+            "type": "user_type",
+            "named": true
+          }
+        ]
+      }
+    }
   },
   {
     "type": "try_expression",

--- a/test/corpus/functions.txt
+++ b/test/corpus/functions.txt
@@ -431,6 +431,49 @@ func iCanDoBetter()
             (integer_literal)))))))
 
 ================================================================================
+Typed throws
+================================================================================
+
+func mayFail() throws(MyError) -> Int { return -1 }
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (function_declaration
+    (simple_identifier)
+    (throws_clause
+      (user_type
+        (type_identifier)))
+    (user_type
+      (type_identifier))
+    (function_body
+      (statements
+        (control_transfer_statement
+          (prefix_expression
+            (integer_literal)))))))
+
+================================================================================
+Typed throws on generic function
+================================================================================
+
+func generic<E: Error>() throws(E) {}
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (function_declaration
+    (simple_identifier)
+    (type_parameters
+      (type_parameter
+        (type_identifier)
+        (user_type
+          (type_identifier))))
+    (throws_clause
+      (user_type
+        (type_identifier)))
+    (function_body)))
+
+================================================================================
 Async functions
 ================================================================================
 

--- a/test/corpus/types.txt
+++ b/test/corpus/types.txt
@@ -362,3 +362,26 @@ func q(using p: any P) { }
         (user_type
           (type_identifier))))
     (function_body)))
+
+================================================================================
+Typed throws in function type
+================================================================================
+
+let closure: () throws(MyError) -> Void = {}
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (property_declaration
+    (value_binding_pattern)
+    (pattern
+      (simple_identifier))
+    (type_annotation
+      (function_type
+        (tuple_type)
+        (throws_clause
+          (user_type
+            (type_identifier)))
+        (user_type
+          (type_identifier))))
+    (lambda_literal)))


### PR DESCRIPTION
Implements SE-0413 typed throws syntax. Adds a `throws_clause` node wrapping `_throws_keyword` with a parenthesized error type, using `field("type", $._unannotated_type)` for a clean single field.

Five positions updated from `optional($.throws)` to `optional(choice($.throws_clause, $.throws))`, preserving existing `throws` and `rethrows` behaviour:
- `function_type`
- `lambda_function_type`
- `_modifierless_function_declaration_no_body` (func declarations)
- `init_declaration`
- `_getter_effects`

Corpus tests cover all three positions from #565: function declarations, generic functions, and function-type annotations.

Closes #565