### PR TITLE
Add do throws(E) do-catch syntax -- SE-0413

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tree-sitter-swift"
 description = "swift grammar for the tree-sitter parsing library"
-version = "0.7.1"
+version = "0.7.2"
 keywords = ["incremental", "parsing", "swift"]
 categories = ["parsing", "text-editors"]
 repository = "https://github.com/alex-pinkus/tree-sitter-swift"

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION := 0.7.1
+VERSION := 0.7.2
 
 # Repository
 SRC_DIR := src

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ To use the Rust crate, you'll add this to your `Cargo.toml`:
 
 ```
 tree-sitter = "0.23.0"
-tree-sitter-swift = "=0.7.1"
+tree-sitter-swift = "=0.7.2"
 ```
 
 Then you can use a `tree-sitter` parser with the language declared here:
@@ -38,7 +38,7 @@ To use this from NPM, you'll add similar dependencies to `package.json`:
 
 ```
 "dependencies: {
-  "tree-sitter-swift": "0.7.1",
+  "tree-sitter-swift": "0.7.2",
   "tree-sitter": "^0.22.1"
 }
 ```

--- a/grammar.js
+++ b/grammar.js
@@ -466,7 +466,7 @@ module.exports = grammar({
       seq(
         field("params", choice($.tuple_type, $._unannotated_type)),
         optional($._async_keyword),
-        optional($.throws),
+        optional(choice($.throws_clause, $.throws)),
         $._arrow_operator,
         field("return_type", $._type)
       ),
@@ -998,7 +998,7 @@ module.exports = grammar({
             seq("(", optional($.lambda_function_type_parameters), ")")
           ),
           optional($._async_keyword),
-          optional($.throws),
+          optional(choice($.throws_clause, $.throws)),
           optional(
             seq(
               $._arrow_operator,
@@ -1471,7 +1471,7 @@ module.exports = grammar({
           optional($.type_parameters),
           $._function_value_parameters,
           optional($._async_keyword),
-          optional($.throws),
+          optional(choice($.throws_clause, $.throws)),
           optional(
             seq(
               $._arrow_operator,
@@ -1664,6 +1664,8 @@ module.exports = grammar({
     _async_keyword: ($) => alias($._async_keyword_custom, "async"),
     _async_modifier: ($) => token("async"),
     throws: ($) => choice($._throws_keyword, $._rethrows_keyword),
+    throws_clause: ($) =>
+      seq($._throws_keyword, "(", field("type", $._unannotated_type), ")"),
     enum_class_body: ($) =>
       seq("{", repeat(choice($.enum_entry, $._type_level_declaration)), "}"),
     enum_entry: ($) =>
@@ -1744,7 +1746,7 @@ module.exports = grammar({
           optional($.type_parameters),
           $._function_value_parameters,
           optional($._async_keyword),
-          optional($.throws),
+          optional(choice($.throws_clause, $.throws)),
           optional($.type_constraints),
           optional(field("body", $.function_body))
         )
@@ -1796,7 +1798,8 @@ module.exports = grammar({
       seq(optional($.mutation_modifier), "get", optional($._getter_effects)),
     setter_specifier: ($) => seq(optional($.mutation_modifier), "set"),
     modify_specifier: ($) => seq(optional($.mutation_modifier), "_modify"),
-    _getter_effects: ($) => repeat1(choice($._async_keyword, $.throws)),
+    _getter_effects: ($) =>
+      repeat1(choice($._async_keyword, $.throws_clause, $.throws)),
     operator_declaration: ($) =>
       seq(
         choice("prefix", "infix", "postfix"),

--- a/grammar.js
+++ b/grammar.js
@@ -1087,7 +1087,15 @@ module.exports = grammar({
       ),
     switch_pattern: ($) => alias($._binding_pattern_with_expr, $.pattern),
     do_statement: ($) =>
-      prec.right(PRECS["do"], seq("do", $._block, repeat($.catch_block))),
+      prec.right(
+        PRECS["do"],
+        seq(
+          "do",
+          optional(choice($.throws_clause, $.throws)),
+          $._block,
+          repeat($.catch_block)
+        )
+      ),
     catch_block: ($) =>
       seq(
         $.catch_keyword,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tree-sitter-swift",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "tree-sitter-swift",
-      "version": "0.7.1",
+      "version": "0.7.2",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tree-sitter-swift",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "A tree-sitter grammar for the Swift programming language.",
   "main": "bindings/node/index.js",
   "types": "bindings/node",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "tree-sitter-swift"
 description = "Swift grammar for tree-sitter"
-version = "0.0.1"
+version = "0.7.1"
 keywords = ["incremental", "parsing", "tree-sitter", "swift"]
 classifiers = [
   "Intended Audience :: Developers",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "tree-sitter-swift"
 description = "Swift grammar for tree-sitter"
-version = "0.7.1"
+version = "0.7.2"
 keywords = ["incremental", "parsing", "tree-sitter", "swift"]
 classifiers = [
   "Intended Audience :: Developers",

--- a/script-data/top-repositories.txt
+++ b/script-data/top-repositories.txt
@@ -1,5 +1,5 @@
 Alamofire Alamofire/Alamofire 5.11.2
-iina iina/iina v1.4.1
+iina iina/iina v1.4.2-build164
 Charts danielgindi/Charts 5.1.0
 lottie-ios airbnb/lottie-ios 4.6.0
 vapor vapor/vapor 3.3.3
@@ -36,7 +36,7 @@ AudioKit AudioKit/AudioKit 5.7.2
 Starscream daltoniam/Starscream 4.0.8
 MessageKit MessageKit/MessageKit 5.0.0
 KeychainAccess kishikawakatsumi/KeychainAccess v4.2.2
-Nuke kean/Nuke 13.0.1
+Nuke kean/Nuke 13.0.4
 Swinject Swinject/Swinject 2.10.0
 GRDB groue/GRDB.swift v7.10.0 0 2
 GRDB groue/GRDB.swift v7.10.0 1 2

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -1553,8 +1553,17 @@
           "type": "CHOICE",
           "members": [
             {
-              "type": "SYMBOL",
-              "name": "throws"
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "throws_clause"
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "throws"
+                }
+              ]
             },
             {
               "type": "BLANK"
@@ -4248,8 +4257,17 @@
             "type": "CHOICE",
             "members": [
               {
-                "type": "SYMBOL",
-                "name": "throws"
+                "type": "CHOICE",
+                "members": [
+                  {
+                    "type": "SYMBOL",
+                    "name": "throws_clause"
+                  },
+                  {
+                    "type": "SYMBOL",
+                    "name": "throws"
+                  }
+                ]
               },
               {
                 "type": "BLANK"
@@ -6948,8 +6966,17 @@
             "type": "CHOICE",
             "members": [
               {
-                "type": "SYMBOL",
-                "name": "throws"
+                "type": "CHOICE",
+                "members": [
+                  {
+                    "type": "SYMBOL",
+                    "name": "throws_clause"
+                  },
+                  {
+                    "type": "SYMBOL",
+                    "name": "throws"
+                  }
+                ]
               },
               {
                 "type": "BLANK"
@@ -8323,6 +8350,31 @@
         }
       ]
     },
+    "throws_clause": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "_throws_keyword"
+        },
+        {
+          "type": "STRING",
+          "value": "("
+        },
+        {
+          "type": "FIELD",
+          "name": "type",
+          "content": {
+            "type": "SYMBOL",
+            "name": "_unannotated_type"
+          }
+        },
+        {
+          "type": "STRING",
+          "value": ")"
+        }
+      ]
+    },
     "enum_class_body": {
       "type": "SEQ",
       "members": [
@@ -8970,8 +9022,17 @@
             "type": "CHOICE",
             "members": [
               {
-                "type": "SYMBOL",
-                "name": "throws"
+                "type": "CHOICE",
+                "members": [
+                  {
+                    "type": "SYMBOL",
+                    "name": "throws_clause"
+                  },
+                  {
+                    "type": "SYMBOL",
+                    "name": "throws"
+                  }
+                ]
               },
               {
                 "type": "BLANK"
@@ -9366,6 +9427,10 @@
           {
             "type": "SYMBOL",
             "name": "_async_keyword"
+          },
+          {
+            "type": "SYMBOL",
+            "name": "throws_clause"
           },
           {
             "type": "SYMBOL",

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -4789,6 +4789,27 @@
             "value": "do"
           },
           {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "CHOICE",
+                "members": [
+                  {
+                    "type": "SYMBOL",
+                    "name": "throws_clause"
+                  },
+                  {
+                    "type": "SYMBOL",
+                    "name": "throws"
+                  }
+                ]
+              },
+              {
+                "type": "BLANK"
+              }
+            ]
+          },
+          {
             "type": "SYMBOL",
             "name": "_block"
           },

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -12074,6 +12074,10 @@
           "named": true
         },
         {
+          "type": "throws_clause",
+          "named": true
+        },
+        {
           "type": "type_constraints",
           "named": true
         },
@@ -12279,6 +12283,10 @@
         {
           "type": "throws",
           "named": true
+        },
+        {
+          "type": "throws_clause",
+          "named": true
         }
       ]
     }
@@ -12297,6 +12305,10 @@
         },
         {
           "type": "throws",
+          "named": true
+        },
+        {
+          "type": "throws_clause",
           "named": true
         }
       ]
@@ -14763,6 +14775,10 @@
           "named": true
         },
         {
+          "type": "throws_clause",
+          "named": true
+        },
+        {
           "type": "type_constraints",
           "named": true
         },
@@ -15560,6 +15576,10 @@
         },
         {
           "type": "throws",
+          "named": true
+        },
+        {
+          "type": "throws_clause",
           "named": true
         }
       ]
@@ -22196,6 +22216,10 @@
           "named": true
         },
         {
+          "type": "throws_clause",
+          "named": true
+        },
+        {
           "type": "type_constraints",
           "named": true
         },
@@ -26617,6 +26641,70 @@
     "type": "throws",
     "named": true,
     "fields": {}
+  },
+  {
+    "type": "throws_clause",
+    "named": true,
+    "fields": {
+      "type": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "array_type",
+            "named": true
+          },
+          {
+            "type": "dictionary_type",
+            "named": true
+          },
+          {
+            "type": "existential_type",
+            "named": true
+          },
+          {
+            "type": "function_type",
+            "named": true
+          },
+          {
+            "type": "metatype",
+            "named": true
+          },
+          {
+            "type": "opaque_type",
+            "named": true
+          },
+          {
+            "type": "optional_type",
+            "named": true
+          },
+          {
+            "type": "protocol_composition_type",
+            "named": true
+          },
+          {
+            "type": "suppressed_constraint",
+            "named": true
+          },
+          {
+            "type": "tuple_type",
+            "named": true
+          },
+          {
+            "type": "type_pack_expansion",
+            "named": true
+          },
+          {
+            "type": "type_parameter_pack",
+            "named": true
+          },
+          {
+            "type": "user_type",
+            "named": true
+          }
+        ]
+      }
+    }
   },
   {
     "type": "try_expression",

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -9301,6 +9301,14 @@
         {
           "type": "statements",
           "named": true
+        },
+        {
+          "type": "throws",
+          "named": true
+        },
+        {
+          "type": "throws_clause",
+          "named": true
         }
       ]
     }

--- a/test-npm-package/package-lock.json
+++ b/test-npm-package/package-lock.json
@@ -14,7 +14,7 @@
       }
     },
     "..": {
-      "version": "0.7.1",
+      "version": "0.7.2",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/test/corpus/functions.txt
+++ b/test/corpus/functions.txt
@@ -431,6 +431,49 @@ func iCanDoBetter()
             (integer_literal)))))))
 
 ================================================================================
+Typed throws
+================================================================================
+
+func mayFail() throws(MyError) -> Int { return -1 }
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (function_declaration
+    (simple_identifier)
+    (throws_clause
+      (user_type
+        (type_identifier)))
+    (user_type
+      (type_identifier))
+    (function_body
+      (statements
+        (control_transfer_statement
+          (prefix_expression
+            (integer_literal)))))))
+
+================================================================================
+Typed throws on generic function
+================================================================================
+
+func generic<E: Error>() throws(E) {}
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (function_declaration
+    (simple_identifier)
+    (type_parameters
+      (type_parameter
+        (type_identifier)
+        (user_type
+          (type_identifier))))
+    (throws_clause
+      (user_type
+        (type_identifier)))
+    (function_body)))
+
+================================================================================
 Async functions
 ================================================================================
 

--- a/test/corpus/statements.txt
+++ b/test/corpus/statements.txt
@@ -524,6 +524,72 @@ do {
         (integer_literal)))))
 
 ================================================================================
+Typed throws on do-catch
+================================================================================
+
+do throws(MyError) {
+    try riskyOp()
+} catch {
+    handle(error)
+}
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (do_statement
+    (throws_clause
+      (user_type
+        (type_identifier)))
+    (statements
+      (try_expression
+        (try_operator)
+        (call_expression
+          (simple_identifier)
+          (call_suffix
+            (value_arguments)))))
+    (catch_block
+      (catch_keyword)
+      (statements
+        (call_expression
+          (simple_identifier)
+          (call_suffix
+            (value_arguments
+              (value_argument
+                (simple_identifier)))))))))
+
+================================================================================
+Untyped throws on do-catch
+================================================================================
+
+do throws {
+    try riskyOp()
+} catch {
+    handle(error)
+}
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (do_statement
+    (throws)
+    (statements
+      (try_expression
+        (try_operator)
+        (call_expression
+          (simple_identifier)
+          (call_suffix
+            (value_arguments)))))
+    (catch_block
+      (catch_keyword)
+      (statements
+        (call_expression
+          (simple_identifier)
+          (call_suffix
+            (value_arguments
+              (value_argument
+                (simple_identifier)))))))))
+
+================================================================================
 If let statements
 ================================================================================
 

--- a/test/corpus/types.txt
+++ b/test/corpus/types.txt
@@ -362,3 +362,26 @@ func q(using p: any P) { }
         (user_type
           (type_identifier))))
     (function_body)))
+
+================================================================================
+Typed throws in function type
+================================================================================
+
+let closure: () throws(MyError) -> Void = {}
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (property_declaration
+    (value_binding_pattern)
+    (pattern
+      (simple_identifier))
+    (type_annotation
+      (function_type
+        (tuple_type)
+        (throws_clause
+          (user_type
+            (type_identifier)))
+        (user_type
+          (type_identifier))))
+    (lambda_literal)))

--- a/tree-sitter.json
+++ b/tree-sitter.json
@@ -15,7 +15,7 @@
     }
   ],
   "metadata": {
-    "version": "0.7.1",
+    "version": "0.7.2",
     "license": "MIT",
     "description": "A tree-sitter grammar for the Swift programming language.",
     "authors": [


### PR DESCRIPTION
Adds support for typed and untyped `throws` clauses on `do`-`catch` blocks, as specified in [SE-0413](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0413-typed-throws.md).

This extends the existing `throws_clause` and `throws` nodes (introduced for function declarations in c354345) to `do_statement`.

Grammar change:

- `do_statement` now accepts an optional `throws_clause` or `throws` between the `do` keyword and the block body, matching how Swift 6 allows `do throws(SomeError) { ... } catch { ... }`.

Corpus tests added:

- `do throws(MyError) { try riskyOp() } catch { handle(error) }` (typed throws)
- `do throws { try riskyOp() } catch { handle(error) }` (untyped throws)

All existing and new corpus tests pass with `tree-sitter test`.