### PR TITLE
Add do throws(E) do-catch syntax -- SE-0413

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -1087,7 +1087,15 @@ module.exports = grammar({
       ),
     switch_pattern: ($) => alias($._binding_pattern_with_expr, $.pattern),
     do_statement: ($) =>
-      prec.right(PRECS["do"], seq("do", $._block, repeat($.catch_block))),
+      prec.right(
+        PRECS["do"],
+        seq(
+          "do",
+          optional(choice($.throws_clause, $.throws)),
+          $._block,
+          repeat($.catch_block)
+        )
+      ),
     catch_block: ($) =>
       seq(
         $.catch_keyword,

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -4771,6 +4771,27 @@
             "value": "do"
           },
           {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "CHOICE",
+                "members": [
+                  {
+                    "type": "SYMBOL",
+                    "name": "throws_clause"
+                  },
+                  {
+                    "type": "SYMBOL",
+                    "name": "throws"
+                  }
+                ]
+              },
+              {
+                "type": "BLANK"
+              }
+            ]
+          },
+          {
             "type": "SYMBOL",
             "name": "_block"
           },

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -9301,6 +9301,14 @@
         {
           "type": "statements",
           "named": true
+        },
+        {
+          "type": "throws",
+          "named": true
+        },
+        {
+          "type": "throws_clause",
+          "named": true
         }
       ]
     }

--- a/test/corpus/statements.txt
+++ b/test/corpus/statements.txt
@@ -524,6 +524,72 @@ do {
         (integer_literal)))))
 
 ================================================================================
+Typed throws on do-catch
+================================================================================
+
+do throws(MyError) {
+    try riskyOp()
+} catch {
+    handle(error)
+}
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (do_statement
+    (throws_clause
+      (user_type
+        (type_identifier)))
+    (statements
+      (try_expression
+        (try_operator)
+        (call_expression
+          (simple_identifier)
+          (call_suffix
+            (value_arguments)))))
+    (catch_block
+      (catch_keyword)
+      (statements
+        (call_expression
+          (simple_identifier)
+          (call_suffix
+            (value_arguments
+              (value_argument
+                (simple_identifier)))))))))
+
+================================================================================
+Untyped throws on do-catch
+================================================================================
+
+do throws {
+    try riskyOp()
+} catch {
+    handle(error)
+}
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (do_statement
+    (throws)
+    (statements
+      (try_expression
+        (try_operator)
+        (call_expression
+          (simple_identifier)
+          (call_suffix
+            (value_arguments)))))
+    (catch_block
+      (catch_keyword)
+      (statements
+        (call_expression
+          (simple_identifier)
+          (call_suffix
+            (value_arguments
+              (value_argument
+                (simple_identifier)))))))))
+
+================================================================================
 If let statements
 ================================================================================
 


### PR DESCRIPTION
Extends typed throws support (SE-0413) to `do` statements. The `throws_clause` node introduced for function declarations now also applies to do-catch bodies, enabling both typed and untyped throws annotations on `do` blocks.

Swift Evolution proposal: [SE-0413 – Typed throws](https://github.com/apple/swift-evolution/blob/main/proposals/0413-typed-throws.md)

Example corpus cases covered:

```swift
// typed throws on do-catch
do throws(E) {
    try foo()
} catch {
}

// untyped throws on do-catch (explicit)
do throws {
    try foo()
} catch {
}
```

All existing corpus tests continue to pass.