### PR TITLE
Fix parsing of double-optional types (Type??) in lambda parameters

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -488,7 +488,16 @@ module.exports = grammar({
             "wrapped",
             choice($.user_type, $.tuple_type, $.array_type, $.dictionary_type)
           ),
-          repeat1(alias($._immediate_quest, "?"))
+          repeat1(
+            choice(
+              alias($._immediate_quest, "?"),
+              // The external scanner always tokenizes `??` as NIL_COALESCING_OPERATOR.
+              // In type position (e.g. `(v: AnyObject??)`) that single token represents
+              // two consecutive optional markers; accept it here since nil-coalescing is
+              // an expression-only construct and cannot appear in a type.
+              alias($._nil_coalescing_operator, "??")
+            )
+          )
         )
       ),
     metatype: ($) => seq($._unannotated_type, ".", choice("Type", "Protocol")),

--- a/script-data/known_failures.txt
+++ b/script-data/known_failures.txt
@@ -1,1 +1,0 @@
-ReactKit/ReactKitTests/OperationTests.swift

--- a/scripts/top-repos.sh
+++ b/scripts/top-repos.sh
@@ -70,7 +70,8 @@ function validate() {
 # It's really easy to add a blank line to `known_failures.txt`, which will make everything pass.
 # This echoes some string from random.org to prove that the grp isn't excluding everything. If we
 # added a blank line, this would have zero items, which results in a nonzero exit code from grep.
-if ! echo "vkDSrg8n" | grep -v -f "$known_failures" > /dev/null; then
+# An entirely empty file is legitimate (no tolerated failures) and should not trip this guard.
+if [ -s "$known_failures" ] && ! echo "vkDSrg8n" | grep -v -f "$known_failures" > /dev/null; then
   echo "You added a blank line to known_failures!"
   exit 1
 fi

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -1680,13 +1680,27 @@
           {
             "type": "REPEAT1",
             "content": {
-              "type": "ALIAS",
-              "content": {
-                "type": "SYMBOL",
-                "name": "_immediate_quest"
-              },
-              "named": false,
-              "value": "?"
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "ALIAS",
+                  "content": {
+                    "type": "SYMBOL",
+                    "name": "_immediate_quest"
+                  },
+                  "named": false,
+                  "value": "?"
+                },
+                {
+                  "type": "ALIAS",
+                  "content": {
+                    "type": "SYMBOL",
+                    "name": "_nil_coalescing_operator"
+                  },
+                  "named": false,
+                  "value": "??"
+                }
+              ]
             }
           }
         ]

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -5,6 +5,11 @@
     "fields": {}
   },
   {
+    "type": "??",
+    "named": false,
+    "fields": {}
+  },
+  {
     "type": "additive_expression",
     "named": true,
     "fields": {

--- a/test/corpus/types.txt
+++ b/test/corpus/types.txt
@@ -241,6 +241,64 @@ private var dictionary: [String: Any?]?
               (type_identifier))))))))
 
 ================================================================================
+Double optional in lambda parameter
+================================================================================
+
+let closure = { (v: AnyObject??) -> String? in
+    return nil
+}
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (property_declaration
+    (value_binding_pattern)
+    (pattern
+      (simple_identifier))
+    (lambda_literal
+      (lambda_function_type
+        (lambda_function_type_parameters
+          (lambda_parameter
+            (simple_identifier)
+            (optional_type
+              (user_type
+                (type_identifier)))))
+        (optional_type
+          (user_type
+            (type_identifier))))
+      (statements
+        (control_transfer_statement)))))
+
+================================================================================
+Double optional array element in lambda parameter (ReactKit regression)
+================================================================================
+
+let closure = { (values: [AnyObject??], _) -> String? in nil }
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (property_declaration
+    (value_binding_pattern)
+    (pattern
+      (simple_identifier))
+    (lambda_literal
+      (lambda_function_type
+        (lambda_function_type_parameters
+          (lambda_parameter
+            (simple_identifier)
+            (array_type
+              (optional_type
+                (user_type
+                  (type_identifier)))))
+          (lambda_parameter
+            (simple_identifier)))
+        (optional_type
+          (user_type
+            (type_identifier))))
+      (statements))))
+
+================================================================================
 Implicitly unwrapped optional types
 ================================================================================
 


### PR DESCRIPTION
## Problem

Double-optional types (`Type??`) fail to parse in lambda parameter positions. For example:

```swift
let closure = { (v: AnyObject??) -> String? in nil }
```

This produces an `ERROR` node because the external scanner unconditionally tokenizes `??` as `NIL_COALESCING_OPERATOR`. The `optional_type` rule only accepted `?` (via `repeat1(alias($._immediate_quest, "?"))`), so the `??` token was rejected in type position.

The single file in `script-data/known_failures.txt` — `ReactKit/ReactKitTests/OperationTests.swift` (added by Alex Pinkus on 2022-09-03 in `02b04b0`) — is broken by exactly this pattern. It uses `(oldValue: AnyObject??, newValue: AnyObject?)` in closure parameter lists and `[AnyObject??]` in array element types.

## Fix

Extend `optional_type` to accept `$._nil_coalescing_operator` (aliased as `"??"`) as an alternative inside the `repeat1`. In type position, no nil-coalescing expression is valid, so accepting `??` as two consecutive optional markers is unambiguous.

```js
repeat1(
  choice(
    alias($._immediate_quest, "?"),
    // The external scanner always tokenizes `??` as NIL_COALESCING_OPERATOR.
    // In type position (e.g. `(v: AnyObject??)`) that single token represents
    // two consecutive optional markers; accept it here since nil-coalescing is
    // an expression-only construct and cannot appear in a type.
    alias($._nil_coalescing_operator, "??")
  )
)
```

## ReactKit unblock + script guard fix

With the grammar fix, `ReactKit/ReactKitTests/OperationTests.swift` now parses cleanly, so it's removed from `script-data/known_failures.txt`. That leaves the file empty, which trips a pre-existing safety guard in `scripts/top-repos.sh`:

```bash
if ! echo "vkDSrg8n" | grep -v -f "$known_failures" > /dev/null; then
  echo "You added a blank line to known_failures!"
  exit 1
fi
```

`grep -v -f <empty-file>` returns exit 1 (no patterns means everything matches the filter), so the guard fires even though the file is intentionally empty (no failures left to track). Fixed by gating the check on `[ -s "$known_failures" ]` so it only runs when the file is non-empty. The blank-line semantics for non-empty files are preserved.

## Test coverage

| Test | Position |
|---|---|
| `Double optional in lambda parameter` | `(v: AnyObject??) -> String?` |
| `Double optional array element in lambda parameter (ReactKit regression)` | `[AnyObject??]` — exact pattern from `OperationTests.swift` |

Both new tests pass. All 231 pre-existing corpus tests continue to pass (233/233 total).

## Files

| File | Change |
|---|---|
| `grammar.js` | `optional_type` accepts `??` as alternative to `?` |
| `src/grammar.json` | regenerated |
| `src/node-types.json` | regenerated |
| `test/corpus/types.txt` | two new corpus tests |
| `script-data/known_failures.txt` | ReactKit entry removed (file now empty) |
| `scripts/top-repos.sh` | blank-line guard skipped when known_failures is empty |