### PR TITLE
Add nonisolated(unsafe) member modifier

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -2021,7 +2021,7 @@ module.exports = grammar({
     property_behavior_modifier: ($) => "lazy",
     type_modifiers: ($) => repeat1($.attribute),
     member_modifier: ($) =>
-      choice("override", "convenience", "required", "nonisolated"),
+      choice("override", "convenience", "required", "nonisolated", "nonisolated(unsafe)"),
     visibility_modifier: ($) =>
       seq(
         choice(

--- a/grammar.js
+++ b/grammar.js
@@ -2021,7 +2021,13 @@ module.exports = grammar({
     property_behavior_modifier: ($) => "lazy",
     type_modifiers: ($) => repeat1($.attribute),
     member_modifier: ($) =>
-      choice("override", "convenience", "required", "nonisolated", "nonisolated(unsafe)"),
+      choice(
+        "override",
+        "convenience",
+        "required",
+        "nonisolated",
+        "nonisolated(unsafe)"
+      ),
     visibility_modifier: ($) =>
       seq(
         choice(

--- a/package.json
+++ b/package.json
@@ -6,9 +6,13 @@
   "types": "bindings/node",
   "scripts": {
     "install": "node-gyp-build",
-    "prestart": "tree-sitter build --wasm",
-    "start": "tree-sitter playground",
-    "test": "node --test bindings/node/*_test.js"
+    "postinstall": "node-gyp configure && node-gyp build",
+    "build": "tree-sitter generate --no-bindings",
+    "build-wasm": "tree-sitter build --wasm",
+    "ci": "prettier --check grammar.js",
+    "test-ci": "./scripts/test-with-memcheck.sh --install-valgrind",
+    "test": "./scripts/test-with-memcheck.sh",
+    "prebuildify": "prebuildify --napi --strip"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -6,13 +6,9 @@
   "types": "bindings/node",
   "scripts": {
     "install": "node-gyp-build",
-    "postinstall": "node-gyp configure && node-gyp build",
-    "build": "tree-sitter generate --no-bindings",
-    "build-wasm": "tree-sitter build --wasm",
-    "ci": "prettier --check grammar.js",
-    "test-ci": "./scripts/test-with-memcheck.sh --install-valgrind",
-    "test": "./scripts/test-with-memcheck.sh",
-    "prebuildify": "prebuildify --napi --strip"
+    "prestart": "tree-sitter build --wasm",
+    "start": "tree-sitter playground",
+    "test": "node --test bindings/node/*_test.js"
   },
   "repository": {
     "type": "git",

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -1,5 +1,4 @@
 {
-  "$schema": "https://tree-sitter.github.io/tree-sitter/assets/schemas/grammar.schema.json",
   "name": "swift",
   "rules": {
     "source_file": {
@@ -10571,6 +10570,10 @@
         {
           "type": "STRING",
           "value": "nonisolated"
+        },
+        {
+          "type": "STRING",
+          "value": "nonisolated(unsafe)"
         }
       ]
     },
@@ -11531,6 +11534,5 @@
   "inline": [
     "_locally_permitted_modifiers"
   ],
-  "supertypes": [],
-  "reserved": {}
+  "supertypes": []
 }

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -24700,7 +24700,6 @@
   {
     "type": "source_file",
     "named": true,
-    "root": true,
     "fields": {},
     "children": {
       "multiple": true,
@@ -31274,8 +31273,7 @@
   },
   {
     "type": "comment",
-    "named": true,
-    "extra": true
+    "named": true
   },
   {
     "type": "compiler",
@@ -31303,6 +31301,10 @@
   },
   {
     "type": "deinit",
+    "named": false
+  },
+  {
+    "type": "delegate",
     "named": false
   },
   {
@@ -31475,8 +31477,7 @@
   },
   {
     "type": "multiline_comment",
-    "named": true,
-    "extra": true
+    "named": true
   },
   {
     "type": "mutating",
@@ -31488,6 +31489,10 @@
   },
   {
     "type": "nonisolated",
+    "named": false
+  },
+  {
+    "type": "nonisolated(unsafe)",
     "named": false
   },
   {
@@ -31523,6 +31528,10 @@
     "named": false
   },
   {
+    "type": "param",
+    "named": false
+  },
+  {
     "type": "postfix",
     "named": false
   },
@@ -31536,6 +31545,10 @@
   },
   {
     "type": "private",
+    "named": false
+  },
+  {
+    "type": "property",
     "named": false
   },
   {
@@ -31567,6 +31580,10 @@
     "named": true
   },
   {
+    "type": "receiver",
+    "named": false
+  },
+  {
     "type": "repeat",
     "named": false
   },
@@ -31588,6 +31605,10 @@
   },
   {
     "type": "set",
+    "named": false
+  },
+  {
+    "type": "setparam",
     "named": false
   },
   {
@@ -31640,6 +31661,14 @@
   },
   {
     "type": "try",
+    "named": false
+  },
+  {
+    "type": "try!",
+    "named": false
+  },
+  {
+    "type": "try?",
     "named": false
   },
   {

--- a/test/corpus/classes.txt
+++ b/test/corpus/classes.txt
@@ -1716,3 +1716,25 @@ struct Foo<T: ~Copyable>: ~Copyable {
         (type_annotation
           (user_type
             (type_identifier)))))))
+
+================================================================================
+Class with nonisolated(unsafe) member
+================================================================================
+
+class Document {
+    nonisolated(unsafe) var flag = false
+}
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (class_declaration
+    name: (type_identifier)
+    body: (class_body
+      (property_declaration
+        (modifiers
+          (member_modifier))
+        (value_binding_pattern)
+        name: (pattern
+          bound_identifier: (simple_identifier))
+        value: (boolean_literal)))))

--- a/test/corpus/classes.txt
+++ b/test/corpus/classes.txt
@@ -1738,3 +1738,42 @@ class Document {
         name: (pattern
           bound_identifier: (simple_identifier))
         value: (boolean_literal)))))
+
+================================================================================
+Class with both nonisolated variants
+================================================================================
+
+class Counter {
+    nonisolated var safe = 0
+    nonisolated(unsafe) var unsafe = 0
+    private nonisolated(unsafe) var privateUnsafe = 0
+}
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (class_declaration
+    name: (type_identifier)
+    body: (class_body
+      (property_declaration
+        (modifiers
+          (member_modifier))
+        (value_binding_pattern)
+        name: (pattern
+          bound_identifier: (simple_identifier))
+        value: (integer_literal))
+      (property_declaration
+        (modifiers
+          (member_modifier))
+        (value_binding_pattern)
+        name: (pattern
+          bound_identifier: (simple_identifier))
+        value: (integer_literal))
+      (property_declaration
+        (modifiers
+          (visibility_modifier)
+          (member_modifier))
+        (value_binding_pattern)
+        name: (pattern
+          bound_identifier: (simple_identifier))
+        value: (integer_literal)))))


### PR DESCRIPTION
## Problem

The grammar did not recognize `nonisolated(unsafe)` as a valid member modifier, causing class declarations with `nonisolated(unsafe)` members to parse as ERROR nodes. This breaks downstream tooling that relies on stable class_declaration shapes for symbol extraction and outline views.

## Fix

Add `nonisolated(unsafe)` to the `member_modifier` choice alongside the existing `nonisolated` token. This allows the parser to correctly handle both variants of the nonisolated modifier introduced in Swift's evolution proposals.

Adds comprehensive corpus tests covering:
- Class with single `nonisolated(unsafe)` member
- Class with both `nonisolated` and `nonisolated(unsafe)` variants
- Visibility modifier combinations (`private nonisolated(unsafe)`)

Fixes #550