### PR TITLE
Support parenthesized nonisolated modifier: nonisolated(unsafe) / nonisolated(nonsending)

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -2021,7 +2021,17 @@ module.exports = grammar({
     property_behavior_modifier: ($) => "lazy",
     type_modifiers: ($) => repeat1($.attribute),
     member_modifier: ($) =>
-      choice("override", "convenience", "required", "nonisolated"),
+      choice(
+        "override",
+        "convenience",
+        "required",
+        // `nonisolated` may optionally take a parenthesized argument: `nonisolated(unsafe)`
+        // (SE-0414-style escape hatch) or `nonisolated(nonsending)` (SE-0461).
+        seq(
+          "nonisolated",
+          optional(seq("(", choice("unsafe", "nonsending"), ")"))
+        )
+      ),
     visibility_modifier: ($) =>
       seq(
         choice(

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -10569,8 +10569,47 @@
           "value": "required"
         },
         {
-          "type": "STRING",
-          "value": "nonisolated"
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "STRING",
+              "value": "nonisolated"
+            },
+            {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SEQ",
+                  "members": [
+                    {
+                      "type": "STRING",
+                      "value": "("
+                    },
+                    {
+                      "type": "CHOICE",
+                      "members": [
+                        {
+                          "type": "STRING",
+                          "value": "unsafe"
+                        },
+                        {
+                          "type": "STRING",
+                          "value": "nonsending"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "STRING",
+                      "value": ")"
+                    }
+                  ]
+                },
+                {
+                  "type": "BLANK"
+                }
+              ]
+            }
+          ]
         }
       ]
     },

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -31495,6 +31495,10 @@
     "named": false
   },
   {
+    "type": "nonsending",
+    "named": false
+  },
+  {
     "type": "oct_literal",
     "named": true
   },
@@ -31664,6 +31668,10 @@
   },
   {
     "type": "unowned(unsafe)",
+    "named": false
+  },
+  {
+    "type": "unsafe",
     "named": false
   },
   {

--- a/test/corpus/classes.txt
+++ b/test/corpus/classes.txt
@@ -1546,6 +1546,52 @@ private actor CounterActor {
                           (value_arguments))))))))))))))
 
 ================================================================================
+nonisolated(unsafe) property
+================================================================================
+
+class Registry {
+    nonisolated(unsafe) static var instance = Registry()
+}
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (class_declaration
+    (type_identifier)
+    (class_body
+      (property_declaration
+        (modifiers
+          (member_modifier)
+          (property_modifier))
+        (value_binding_pattern)
+        (pattern
+          (simple_identifier))
+        (call_expression
+          (simple_identifier)
+          (call_suffix
+            (value_arguments)))))))
+
+================================================================================
+nonisolated(nonsending) function
+================================================================================
+
+actor A {
+    nonisolated(nonsending) func work() async {}
+}
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (class_declaration
+    (type_identifier)
+    (class_body
+      (function_declaration
+        (modifiers
+          (member_modifier))
+        (simple_identifier)
+        (function_body)))))
+
+================================================================================
 Lazy is usable as a computed property
 ================================================================================
 


### PR DESCRIPTION
## Problem

The `member_modifier` rule only accepts plain `nonisolated`. Modern Swift introduces parenthesized variants:

- `nonisolated(unsafe)` — escape hatch for unsafe-global properties (SE-0414 era)
- `nonisolated(nonsending)` — non-inheriting isolation default (SE-0461)

Both forms appear extensively in real Swift code (any module that needs an unsafe-global static, plus modern Swift 6.2+ codebases using nonsending). They currently produce ERROR nodes in the AST.

## Fix

Extend the `member_modifier` choice to accept the parenthesized form:

```js
member_modifier: ($) =>
  choice(
    "override",
    "convenience",
    "required",
    seq("nonisolated", optional(seq("(", choice("unsafe", "nonsending"), ")")))
  ),
```

The plain `nonisolated` form continues to parse via the optional inner seq.

## Test coverage

- `test/corpus/classes.txt`: two new corpus tests (`nonisolated(unsafe) property` and `nonisolated(nonsending) function`).
- All 233 pre-existing corpus tests continue to pass; total 235.

## Files

| File | Change |
|---|---|
| `grammar.js` | `member_modifier` accepts parenthesized arguments |
| `src/grammar.json` | regenerated |
| `src/node-types.json` | regenerated |
| `test/corpus/classes.txt` | 2 new corpus tests |