### PR TITLE
Allow #if/#elseif/#else/#endif directives inside type bodies

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -1646,7 +1646,10 @@ module.exports = grammar({
     _class_member_separator: ($) => choice($._semi, $.multiline_comment),
     _class_member_declarations: ($) =>
       seq(
-        sep1($._type_level_declaration, $._class_member_separator),
+        sep1(
+          choice($._type_level_declaration, $.directive),
+          $._class_member_separator
+        ),
         optional($._class_member_separator)
       ),
     _function_value_parameters: ($) =>
@@ -1715,7 +1718,11 @@ module.exports = grammar({
     throws_clause: ($) =>
       seq($._throws_keyword, "(", field("type", $._unannotated_type), ")"),
     enum_class_body: ($) =>
-      seq("{", repeat(choice($.enum_entry, $._type_level_declaration)), "}"),
+      seq(
+        "{",
+        repeat(choice($.enum_entry, $._type_level_declaration, $.directive)),
+        "}"
+      ),
     enum_entry: ($) =>
       seq(
         optional($.modifiers),
@@ -1767,7 +1774,10 @@ module.exports = grammar({
     protocol_body: ($) =>
       seq("{", optional($._protocol_member_declarations), "}"),
     _protocol_member_declarations: ($) =>
-      seq(sep1($._protocol_member_declaration, $._semi), optional($._semi)),
+      seq(
+        sep1(choice($._protocol_member_declaration, $.directive), $._semi),
+        optional($._semi)
+      ),
     _protocol_member_declaration: ($) =>
       choice(
         alias(

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -8043,8 +8043,17 @@
           "type": "SEQ",
           "members": [
             {
-              "type": "SYMBOL",
-              "name": "_type_level_declaration"
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "_type_level_declaration"
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "directive"
+                }
+              ]
             },
             {
               "type": "REPEAT",
@@ -8056,8 +8065,17 @@
                     "name": "_class_member_separator"
                   },
                   {
-                    "type": "SYMBOL",
-                    "name": "_type_level_declaration"
+                    "type": "CHOICE",
+                    "members": [
+                      {
+                        "type": "SYMBOL",
+                        "name": "_type_level_declaration"
+                      },
+                      {
+                        "type": "SYMBOL",
+                        "name": "directive"
+                      }
+                    ]
                   }
                 ]
               }
@@ -8530,6 +8548,10 @@
               {
                 "type": "SYMBOL",
                 "name": "_type_level_declaration"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "directive"
               }
             ]
           }
@@ -8973,8 +8995,17 @@
           "type": "SEQ",
           "members": [
             {
-              "type": "SYMBOL",
-              "name": "_protocol_member_declaration"
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "_protocol_member_declaration"
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "directive"
+                }
+              ]
             },
             {
               "type": "REPEAT",
@@ -8986,8 +9017,17 @@
                     "name": "_semi"
                   },
                   {
-                    "type": "SYMBOL",
-                    "name": "_protocol_member_declaration"
+                    "type": "CHOICE",
+                    "members": [
+                      {
+                        "type": "SYMBOL",
+                        "name": "_protocol_member_declaration"
+                      },
+                      {
+                        "type": "SYMBOL",
+                        "name": "directive"
+                      }
+                    ]
                   }
                 ]
               }

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -5107,6 +5107,10 @@
           "named": true
         },
         {
+          "type": "directive",
+          "named": true
+        },
+        {
           "type": "function_declaration",
           "named": true
         },
@@ -9899,6 +9903,10 @@
         },
         {
           "type": "deinit_declaration",
+          "named": true
+        },
+        {
+          "type": "directive",
           "named": true
         },
         {
@@ -22242,6 +22250,10 @@
         },
         {
           "type": "deinit_declaration",
+          "named": true
+        },
+        {
+          "type": "directive",
           "named": true
         },
         {

--- a/test/corpus/classes.txt
+++ b/test/corpus/classes.txt
@@ -1546,6 +1546,72 @@ private actor CounterActor {
                           (value_arguments))))))))))))))
 
 ================================================================================
+#if directive inside enum body
+================================================================================
+
+public enum Shape {
+    case circle
+    #if os(iOS)
+    case square
+    #endif
+}
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (class_declaration
+    (modifiers
+      (visibility_modifier))
+    (type_identifier)
+    (enum_class_body
+      (enum_entry
+        (simple_identifier))
+      (ERROR)
+      (directive
+        (simple_identifier))
+      (enum_entry
+        (simple_identifier))
+      (ERROR)
+      (directive))))
+
+================================================================================
+#if directive inside class body
+================================================================================
+
+class Feature {
+    var a = 0
+    #if os(iOS)
+    var b = 0
+    #endif
+    var c = 0
+}
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (class_declaration
+    (type_identifier)
+    (class_body
+      (property_declaration
+        (value_binding_pattern)
+        (pattern
+          (simple_identifier))
+        (integer_literal))
+      (directive
+        (simple_identifier))
+      (property_declaration
+        (value_binding_pattern)
+        (pattern
+          (simple_identifier))
+        (integer_literal))
+      (directive)
+      (property_declaration
+        (value_binding_pattern)
+        (pattern
+          (simple_identifier))
+        (integer_literal)))))
+
+================================================================================
 Lazy is usable as a computed property
 ================================================================================
 


### PR DESCRIPTION
## Problem

Compilation directives (`#if`, `#elseif`, `#else`, `#endif`) appearing between members inside an enum, class, struct, extension, or protocol body cause one of two failure modes:

1. **Enum bodies fail entirely**: A pattern like
   ```swift
   public enum E {
       case a
       #if os(iOS)
       case b
       #endif
   }
   ```
   produces an `ERROR` node spanning the entire enum body. The grammar's `enum_class_body` only accepts `enum_entry` and `_type_level_declaration`, neither of which include `directive`.

2. **Class/struct/extension bodies silently mis-parse**: The same pattern inside a class body parses without an `ERROR` node, but the members between `#if` and `#endif` float up to file scope rather than being nested inside the type. Downstream tools that walk the parse tree get the wrong AST shape.

This pattern is pervasive in cross-platform Swift codebases that need conditional members for `os(iOS)` vs `os(tvOS)` vs `os(watchOS)` etc.

## Fix

Add `$.directive` as a choice alongside the existing entry kinds in three rules:

- `enum_class_body`
- `_class_member_declarations` (covers class, struct, extension, actor)
- `_protocol_member_declarations`

```js
enum_class_body: ($) =>
  seq("{", repeat(choice($.enum_entry, $._type_level_declaration, $.directive)), "}"),

_class_member_declarations: ($) =>
  seq(
    sep1(choice($._type_level_declaration, $.directive), $._class_member_separator),
    optional($._class_member_separator),
  ),

_protocol_member_declarations: ($) =>
  seq(
    sep1(choice($._protocol_member_declaration, $.directive), $._semi),
    optional($._semi),
  ),
```

The `directive` rule itself is unchanged — it already exists as a top-level construct (defined at `grammar.js:2076`). This PR only allows it as a member-level construct.

## Known cosmetic limitation

Zero-width `(ERROR)` nodes are emitted immediately before each directive inside an enum body. The structural parse is correct (the directive and surrounding entries appear in the right place in the tree), but the parse-error count is non-zero. The behavior is captured in the corpus test so it's locked in while the cosmetic issue can be addressed separately. Cause: external scanner's implicit-semi handling between members and directive tokens.

## Test coverage

- `test/corpus/classes.txt`: two new corpus tests (`#if directive inside enum body`, `#if directive inside class body`).
- All 233 pre-existing corpus tests continue to pass; total 235.

## Files

| File | Change |
|---|---|
| `grammar.js` | three rules extended to accept `$.directive` |
| `src/grammar.json` | regenerated |
| `src/node-types.json` | regenerated |
| `test/corpus/classes.txt` | 2 new corpus tests |