### PR TITLE
Support bracket-qualified nested type access (Type<[T].Index>)

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -425,6 +425,7 @@ module.exports = grammar({
           $.dictionary_type,
           $.optional_type,
           $.metatype,
+          $.bracket_qualified_type,
           $.opaque_type,
           $.existential_type,
           $.protocol_composition_type,
@@ -501,6 +502,20 @@ module.exports = grammar({
         )
       ),
     metatype: ($) => seq($._unannotated_type, ".", choice("Type", "Protocol")),
+    // `[Element].Index` and `[Key: Value].Index` are equivalent to
+    // `Array<Element>.Index` and `Dictionary<Key, Value>.Index`. The grammar
+    // already models `Array<T>.Index` via `user_type` (nested identifiers via
+    // `_dot`), but the bracket-literal form needs its own rule. Narrow the
+    // left-hand side to just the two bracket forms to avoid conflicts with
+    // tuple types, parameter packs, and other constructs.
+    bracket_qualified_type: ($) =>
+      prec.left(
+        PRECS.ty,
+        seq(
+          choice($.array_type, $.dictionary_type),
+          repeat1(seq(".", alias($.simple_identifier, $.type_identifier)))
+        )
+      ),
     _quest: ($) => "?",
     _immediate_quest: ($) => token.immediate("?"),
     opaque_type: ($) => prec.right(seq("some", $._unannotated_type)),

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -1291,6 +1291,10 @@
           },
           {
             "type": "SYMBOL",
+            "name": "bracket_qualified_type"
+          },
+          {
+            "type": "SYMBOL",
             "name": "opaque_type"
           },
           {
@@ -1731,6 +1735,49 @@
           ]
         }
       ]
+    },
+    "bracket_qualified_type": {
+      "type": "PREC_LEFT",
+      "value": -1,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "array_type"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "dictionary_type"
+              }
+            ]
+          },
+          {
+            "type": "REPEAT1",
+            "content": {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "STRING",
+                  "value": "."
+                },
+                {
+                  "type": "ALIAS",
+                  "content": {
+                    "type": "SYMBOL",
+                    "name": "simple_identifier"
+                  },
+                  "named": true,
+                  "value": "type_identifier"
+                }
+              ]
+            }
+          }
+        ]
+      }
     },
     "_quest": {
       "type": "STRING",

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -1098,6 +1098,10 @@
             "named": true
           },
           {
+            "type": "bracket_qualified_type",
+            "named": true
+          },
+          {
             "type": "dictionary_type",
             "named": true
           },
@@ -1157,6 +1161,10 @@
         "types": [
           {
             "type": "array_type",
+            "named": true
+          },
+          {
+            "type": "bracket_qualified_type",
             "named": true
           },
           {
@@ -1574,6 +1582,10 @@
             "named": true
           },
           {
+            "type": "bracket_qualified_type",
+            "named": true
+          },
+          {
             "type": "dictionary_type",
             "named": true
           },
@@ -1629,6 +1641,10 @@
         "types": [
           {
             "type": "array_type",
+            "named": true
+          },
+          {
+            "type": "bracket_qualified_type",
             "named": true
           },
           {
@@ -2111,6 +2127,10 @@
             "named": true
           },
           {
+            "type": "bracket_qualified_type",
+            "named": true
+          },
+          {
             "type": "dictionary_type",
             "named": true
           },
@@ -2173,6 +2193,10 @@
             "named": true
           },
           {
+            "type": "bracket_qualified_type",
+            "named": true
+          },
+          {
             "type": "dictionary_type",
             "named": true
           },
@@ -2232,6 +2256,10 @@
         "types": [
           {
             "type": "array_type",
+            "named": true
+          },
+          {
+            "type": "bracket_qualified_type",
             "named": true
           },
           {
@@ -3899,6 +3927,29 @@
     "fields": {}
   },
   {
+    "type": "bracket_qualified_type",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "array_type",
+          "named": true
+        },
+        {
+          "type": "dictionary_type",
+          "named": true
+        },
+        {
+          "type": "type_identifier",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
     "type": "call_expression",
     "named": true,
     "fields": {},
@@ -4613,6 +4664,10 @@
             "named": true
           },
           {
+            "type": "bracket_qualified_type",
+            "named": true
+          },
+          {
             "type": "dictionary_type",
             "named": true
           },
@@ -5031,6 +5086,10 @@
             "named": true
           },
           {
+            "type": "bracket_qualified_type",
+            "named": true
+          },
+          {
             "type": "dictionary_type",
             "named": true
           },
@@ -5199,6 +5258,10 @@
         "types": [
           {
             "type": "array_type",
+            "named": true
+          },
+          {
+            "type": "bracket_qualified_type",
             "named": true
           },
           {
@@ -8663,6 +8726,10 @@
             "named": true
           },
           {
+            "type": "bracket_qualified_type",
+            "named": true
+          },
+          {
             "type": "dictionary_type",
             "named": true
           },
@@ -8725,6 +8792,10 @@
             "named": true
           },
           {
+            "type": "bracket_qualified_type",
+            "named": true
+          },
+          {
             "type": "dictionary_type",
             "named": true
           },
@@ -8780,6 +8851,10 @@
         "types": [
           {
             "type": "array_type",
+            "named": true
+          },
+          {
+            "type": "bracket_qualified_type",
             "named": true
           },
           {
@@ -10343,6 +10418,10 @@
             "named": true
           },
           {
+            "type": "bracket_qualified_type",
+            "named": true
+          },
+          {
             "type": "dictionary_type",
             "named": true
           },
@@ -10653,6 +10732,10 @@
             "named": true
           },
           {
+            "type": "bracket_qualified_type",
+            "named": true
+          },
+          {
             "type": "dictionary_type",
             "named": true
           },
@@ -10719,6 +10802,10 @@
             "named": true
           },
           {
+            "type": "bracket_qualified_type",
+            "named": true
+          },
+          {
             "type": "dictionary_type",
             "named": true
           },
@@ -10778,6 +10865,10 @@
         "types": [
           {
             "type": "array_type",
+            "named": true
+          },
+          {
+            "type": "bracket_qualified_type",
             "named": true
           },
           {
@@ -11580,6 +11671,10 @@
       "types": [
         {
           "type": "array_type",
+          "named": true
+        },
+        {
+          "type": "bracket_qualified_type",
           "named": true
         },
         {
@@ -12533,6 +12628,10 @@
             "named": true
           },
           {
+            "type": "bracket_qualified_type",
+            "named": true
+          },
+          {
             "type": "custom_operator",
             "named": true
           },
@@ -12608,6 +12707,10 @@
           },
           {
             "type": "array_type",
+            "named": true
+          },
+          {
+            "type": "bracket_qualified_type",
             "named": true
           },
           {
@@ -12730,6 +12833,10 @@
             "named": true
           },
           {
+            "type": "bracket_qualified_type",
+            "named": true
+          },
+          {
             "type": "dictionary_type",
             "named": true
           },
@@ -12788,6 +12895,10 @@
             "named": true
           },
           {
+            "type": "bracket_qualified_type",
+            "named": true
+          },
+          {
             "type": "dictionary_type",
             "named": true
           },
@@ -12843,6 +12954,10 @@
         "types": [
           {
             "type": "array_type",
+            "named": true
+          },
+          {
+            "type": "bracket_qualified_type",
             "named": true
           },
           {
@@ -13133,6 +13248,10 @@
             "named": true
           },
           {
+            "type": "bracket_qualified_type",
+            "named": true
+          },
+          {
             "type": "call_expression",
             "named": true
           },
@@ -13424,6 +13543,10 @@
         "types": [
           {
             "type": "array_type",
+            "named": true
+          },
+          {
+            "type": "bracket_qualified_type",
             "named": true
           },
           {
@@ -13702,6 +13825,10 @@
             "named": true
           },
           {
+            "type": "bracket_qualified_type",
+            "named": true
+          },
+          {
             "type": "call_expression",
             "named": true
           },
@@ -13993,6 +14120,10 @@
         "types": [
           {
             "type": "array_type",
+            "named": true
+          },
+          {
+            "type": "bracket_qualified_type",
             "named": true
           },
           {
@@ -14817,6 +14948,10 @@
             "named": true
           },
           {
+            "type": "bracket_qualified_type",
+            "named": true
+          },
+          {
             "type": "dictionary_type",
             "named": true
           },
@@ -14887,6 +15022,10 @@
             "named": true
           },
           {
+            "type": "bracket_qualified_type",
+            "named": true
+          },
+          {
             "type": "dictionary_type",
             "named": true
           },
@@ -14946,6 +15085,10 @@
         "types": [
           {
             "type": "array_type",
+            "named": true
+          },
+          {
+            "type": "bracket_qualified_type",
             "named": true
           },
           {
@@ -16130,6 +16273,10 @@
             "named": true
           },
           {
+            "type": "bracket_qualified_type",
+            "named": true
+          },
+          {
             "type": "dictionary_type",
             "named": true
           },
@@ -16189,6 +16336,10 @@
           },
           {
             "type": "array_type",
+            "named": true
+          },
+          {
+            "type": "bracket_qualified_type",
             "named": true
           },
           {
@@ -16343,6 +16494,10 @@
             "named": true
           },
           {
+            "type": "bracket_qualified_type",
+            "named": true
+          },
+          {
             "type": "dictionary_type",
             "named": true
           },
@@ -16406,6 +16561,10 @@
           },
           {
             "type": "array_type",
+            "named": true
+          },
+          {
+            "type": "bracket_qualified_type",
             "named": true
           },
           {
@@ -16891,6 +17050,10 @@
           "named": true
         },
         {
+          "type": "bracket_qualified_type",
+          "named": true
+        },
+        {
           "type": "dictionary_type",
           "named": true
         },
@@ -17359,6 +17522,10 @@
       "types": [
         {
           "type": "array_type",
+          "named": true
+        },
+        {
+          "type": "bracket_qualified_type",
           "named": true
         },
         {
@@ -19397,6 +19564,10 @@
           "named": true
         },
         {
+          "type": "bracket_qualified_type",
+          "named": true
+        },
+        {
           "type": "dictionary_type",
           "named": true
         },
@@ -20242,6 +20413,10 @@
             "named": true
           },
           {
+            "type": "bracket_qualified_type",
+            "named": true
+          },
+          {
             "type": "dictionary_type",
             "named": true
           },
@@ -20305,6 +20480,10 @@
           },
           {
             "type": "array_type",
+            "named": true
+          },
+          {
+            "type": "bracket_qualified_type",
             "named": true
           },
           {
@@ -20413,6 +20592,10 @@
         "types": [
           {
             "type": "array_type",
+            "named": true
+          },
+          {
+            "type": "bracket_qualified_type",
             "named": true
           },
           {
@@ -22280,6 +22463,10 @@
           "named": true
         },
         {
+          "type": "bracket_qualified_type",
+          "named": true
+        },
+        {
           "type": "dictionary_type",
           "named": true
         },
@@ -22859,6 +23046,10 @@
             "named": true
           },
           {
+            "type": "bracket_qualified_type",
+            "named": true
+          },
+          {
             "type": "custom_operator",
             "named": true
           },
@@ -22934,6 +23125,10 @@
           },
           {
             "type": "array_type",
+            "named": true
+          },
+          {
+            "type": "bracket_qualified_type",
             "named": true
           },
           {
@@ -24073,6 +24268,10 @@
             "named": true
           },
           {
+            "type": "bracket_qualified_type",
+            "named": true
+          },
+          {
             "type": "call_expression",
             "named": true
           },
@@ -24364,6 +24563,10 @@
         "types": [
           {
             "type": "array_type",
+            "named": true
+          },
+          {
+            "type": "bracket_qualified_type",
             "named": true
           },
           {
@@ -25669,6 +25872,10 @@
             "named": true
           },
           {
+            "type": "bracket_qualified_type",
+            "named": true
+          },
+          {
             "type": "dictionary_type",
             "named": true
           },
@@ -25728,6 +25935,10 @@
           },
           {
             "type": "array_type",
+            "named": true
+          },
+          {
+            "type": "bracket_qualified_type",
             "named": true
           },
           {
@@ -27551,6 +27762,10 @@
             "named": true
           },
           {
+            "type": "bracket_qualified_type",
+            "named": true
+          },
+          {
             "type": "dictionary_type",
             "named": true
           },
@@ -28396,6 +28611,10 @@
             "named": true
           },
           {
+            "type": "bracket_qualified_type",
+            "named": true
+          },
+          {
             "type": "dictionary_type",
             "named": true
           },
@@ -28455,6 +28674,10 @@
         "types": [
           {
             "type": "array_type",
+            "named": true
+          },
+          {
+            "type": "bracket_qualified_type",
             "named": true
           },
           {
@@ -28540,6 +28763,10 @@
             "named": true
           },
           {
+            "type": "bracket_qualified_type",
+            "named": true
+          },
+          {
             "type": "dictionary_type",
             "named": true
           },
@@ -28599,6 +28826,10 @@
           },
           {
             "type": "array_type",
+            "named": true
+          },
+          {
+            "type": "bracket_qualified_type",
             "named": true
           },
           {
@@ -28667,6 +28898,10 @@
         "types": [
           {
             "type": "array_type",
+            "named": true
+          },
+          {
+            "type": "bracket_qualified_type",
             "named": true
           },
           {
@@ -28802,6 +29037,10 @@
           "named": true
         },
         {
+          "type": "bracket_qualified_type",
+          "named": true
+        },
+        {
           "type": "dictionary_type",
           "named": true
         },
@@ -28862,6 +29101,10 @@
         "types": [
           {
             "type": "array_type",
+            "named": true
+          },
+          {
+            "type": "bracket_qualified_type",
             "named": true
           },
           {
@@ -28966,6 +29209,10 @@
           "named": true
         },
         {
+          "type": "bracket_qualified_type",
+          "named": true
+        },
+        {
           "type": "dictionary_type",
           "named": true
         },
@@ -29048,6 +29295,10 @@
             "named": true
           },
           {
+            "type": "bracket_qualified_type",
+            "named": true
+          },
+          {
             "type": "dictionary_type",
             "named": true
           },
@@ -29107,6 +29358,10 @@
         "types": [
           {
             "type": "array_type",
+            "named": true
+          },
+          {
+            "type": "bracket_qualified_type",
             "named": true
           },
           {
@@ -30571,6 +30826,10 @@
             "named": true
           },
           {
+            "type": "bracket_qualified_type",
+            "named": true
+          },
+          {
             "type": "call_expression",
             "named": true
           },
@@ -30862,6 +31121,10 @@
         "types": [
           {
             "type": "array_type",
+            "named": true
+          },
+          {
+            "type": "bracket_qualified_type",
             "named": true
           },
           {

--- a/test/corpus/types.txt
+++ b/test/corpus/types.txt
@@ -443,3 +443,26 @@ let closure: () throws(MyError) -> Void = {}
         (user_type
           (type_identifier))))
     (lambda_literal)))
+
+================================================================================
+Bracket-qualified nested type in generic argument
+================================================================================
+
+func f(range: Range<[String].Index>) {}
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (function_declaration
+    (simple_identifier)
+    (parameter
+      (simple_identifier)
+      (user_type
+        (type_identifier)
+        (type_arguments
+          (bracket_qualified_type
+            (array_type
+              (user_type
+                (type_identifier)))
+            (type_identifier)))))
+    (function_body)))


### PR DESCRIPTION
## Problem

Types of the form `[Element].Index` and `[Key: Value].Keys` are valid Swift type expressions, equivalent to `Array<Element>.Index` and `Dictionary<Key, Value>.Keys`. The grammar's `user_type` rule already handles the nested-identifier form via `sep1(_simple_user_type, _dot)`, but the bracket-literal form was rejected because `array_type` and `dictionary_type` are distinct productions from `user_type`.

This pattern appears in real code — for example in [ReactKit](https://github.com/ReactKit/ReactKit) the same issue motivated the `Range<[Session.Event].Index>` patterns. Currently produces an `ERROR` node.

## Fix

Add a new `bracket_qualified_type` rule that accepts `array_type` or `dictionary_type` followed by one or more `.MemberType` accesses, and include it in `_unannotated_type`:

```js
bracket_qualified_type: ($) =>
  prec.left(
    PRECS.ty,
    seq(
      choice($.array_type, $.dictionary_type),
      repeat1(seq(".", alias($.simple_identifier, $.type_identifier))),
    ),
  ),
```

The LHS is narrowed to bracket forms only. A broader rule that included `tuple_type` and `function_type` regressed the existing "Parameter pack in type constraints" test because tuple LHS conflicts with `(each S).Element` in `tuple_type_item`. Bracket forms have no such dual ownership today, so no conflict declaration is needed — the `[` token uniquely distinguishes them from tuple/function types.

## Test coverage

- `test/corpus/types.txt`: one new corpus test (`Bracket-qualified nested type in generic argument`) using the canonical `Range<[String].Index>` pattern.
- All 233 pre-existing corpus tests continue to pass; total 234.

## Files

| File | Change |
|---|---|
| `grammar.js` | new `bracket_qualified_type` rule, added as a choice in `_unannotated_type` |
| `src/grammar.json` | regenerated |
| `src/node-types.json` | regenerated |
| `test/corpus/types.txt` | 1 new corpus test |