### PR TITLE
Support raw identifiers with spaces (Swift 6.2 / SE-0451)

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -272,7 +272,7 @@ module.exports = grammar({
     simple_identifier: ($) =>
       choice(
         LEXICAL_IDENTIFIER,
-        /`[^\r\n` ]*`/,
+        /`[^\r\n`]+`/,
         /\$[0-9]+/,
         token(seq("$", LEXICAL_IDENTIFIER)),
         $._contextual_simple_identifier

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -1,5 +1,4 @@
 {
-  "$schema": "https://tree-sitter.github.io/tree-sitter/assets/schemas/grammar.schema.json",
   "name": "swift",
   "rules": {
     "source_file": {
@@ -123,7 +122,7 @@
         },
         {
           "type": "PATTERN",
-          "value": "`[^\\r\\n` ]*`"
+          "value": "`[^\\r\\n`]+`"
         },
         {
           "type": "PATTERN",
@@ -11657,6 +11656,5 @@
   "inline": [
     "_locally_permitted_modifiers"
   ],
-  "supertypes": [],
-  "reserved": {}
+  "supertypes": []
 }

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -24915,7 +24915,6 @@
   {
     "type": "source_file",
     "named": true,
-    "root": true,
     "fields": {},
     "children": {
       "multiple": true,
@@ -31549,8 +31548,7 @@
   },
   {
     "type": "comment",
-    "named": true,
-    "extra": true
+    "named": true
   },
   {
     "type": "compiler",
@@ -31578,6 +31576,10 @@
   },
   {
     "type": "deinit",
+    "named": false
+  },
+  {
+    "type": "delegate",
     "named": false
   },
   {
@@ -31750,8 +31752,7 @@
   },
   {
     "type": "multiline_comment",
-    "named": true,
-    "extra": true
+    "named": true
   },
   {
     "type": "mutating",
@@ -31802,6 +31803,10 @@
     "named": false
   },
   {
+    "type": "param",
+    "named": false
+  },
+  {
     "type": "postfix",
     "named": false
   },
@@ -31815,6 +31820,10 @@
   },
   {
     "type": "private",
+    "named": false
+  },
+  {
+    "type": "property",
     "named": false
   },
   {
@@ -31846,6 +31855,10 @@
     "named": true
   },
   {
+    "type": "receiver",
+    "named": false
+  },
+  {
     "type": "repeat",
     "named": false
   },
@@ -31867,6 +31880,10 @@
   },
   {
     "type": "set",
+    "named": false
+  },
+  {
+    "type": "setparam",
     "named": false
   },
   {
@@ -31919,6 +31936,14 @@
   },
   {
     "type": "try",
+    "named": false
+  },
+  {
+    "type": "try!",
+    "named": false
+  },
+  {
+    "type": "try?",
     "named": false
   },
   {

--- a/test/corpus/statements.txt
+++ b/test/corpus/statements.txt
@@ -31,6 +31,25 @@ let `default` = 0
     (integer_literal)))
 
 ================================================================================
+Raw identifiers with spaces (SE-0451)
+================================================================================
+
+let `my value` = 5
+func `my function`() {}
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (property_declaration
+    (value_binding_pattern)
+    (pattern
+      (simple_identifier))
+    (integer_literal))
+  (function_declaration
+    (simple_identifier)
+    (function_body)))
+
+================================================================================
 C-style compound declaration
 ================================================================================
 


### PR DESCRIPTION
SE-0451 extended backtick-escaped identifiers to allow any character
except backtick, LF, and CR — including spaces. This allows names like
`square returns x * x` which is used by Swift Testing's @Test macro.

The previous regex excluded spaces from the character class, preventing
these identifiers from parsing. Remove the space exclusion and tighten
the quantifier to `+` (empty backtick identifiers are not meaningful).

Closes #509

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
