### PR TITLE
Make nil a named node (nil_literal) so it is visible in ternary fields

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -303,7 +303,7 @@ module.exports = grammar({
         $.boolean_literal,
         $._string_literal,
         $.regex_literal,
-        "nil"
+        $.nil_literal
       ),
     real_literal: ($) =>
       token(
@@ -323,6 +323,7 @@ module.exports = grammar({
     oct_literal: ($) => token(seq("0", /[oO]/, OCT_DIGITS)),
     bin_literal: ($) => token(seq("0", /[bB]/, BIN_DIGITS)),
     boolean_literal: ($) => choice("true", "false"),
+    nil_literal: ($) => "nil",
     // String literals
     _string_literal: ($) =>
       choice(

--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -281,7 +281,7 @@
 
 (boolean_literal) @boolean
 
-"nil" @constant.builtin
+(nil_literal) @constant.builtin
 
 (wildcard_pattern) @character.special
 

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -252,8 +252,8 @@
           "name": "regex_literal"
         },
         {
-          "type": "STRING",
-          "value": "nil"
+          "type": "SYMBOL",
+          "name": "nil_literal"
         }
       ]
     },
@@ -809,6 +809,10 @@
           "value": "false"
         }
       ]
+    },
+    "nil_literal": {
+      "type": "STRING",
+      "value": "nil"
     },
     "_string_literal": {
       "type": "CHOICE",

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -262,11 +262,11 @@
             "named": true
           },
           {
-            "type": "nil",
-            "named": false
+            "type": "nil_coalescing_expression",
+            "named": true
           },
           {
-            "type": "nil_coalescing_expression",
+            "type": "nil_literal",
             "named": true
           },
           {
@@ -626,11 +626,11 @@
             "named": true
           },
           {
-            "type": "nil",
-            "named": false
+            "type": "nil_coalescing_expression",
+            "named": true
           },
           {
-            "type": "nil_coalescing_expression",
+            "type": "nil_literal",
             "named": true
           },
           {
@@ -982,11 +982,11 @@
             "named": true
           },
           {
-            "type": "nil",
-            "named": false
+            "type": "nil_coalescing_expression",
+            "named": true
           },
           {
-            "type": "nil_coalescing_expression",
+            "type": "nil_literal",
             "named": true
           },
           {
@@ -1472,11 +1472,11 @@
             "named": true
           },
           {
-            "type": "nil",
-            "named": false
+            "type": "nil_coalescing_expression",
+            "named": true
           },
           {
-            "type": "nil_coalescing_expression",
+            "type": "nil_literal",
             "named": true
           },
           {
@@ -2001,11 +2001,11 @@
             "named": true
           },
           {
-            "type": "nil",
-            "named": false
+            "type": "nil_coalescing_expression",
+            "named": true
           },
           {
-            "type": "nil_coalescing_expression",
+            "type": "nil_literal",
             "named": true
           },
           {
@@ -2485,6 +2485,10 @@
           "named": true
         },
         {
+          "type": "nil_literal",
+          "named": true
+        },
+        {
           "type": "oct_literal",
           "named": true
         },
@@ -2847,11 +2851,11 @@
             "named": true
           },
           {
-            "type": "nil",
-            "named": false
+            "type": "nil_coalescing_expression",
+            "named": true
           },
           {
-            "type": "nil_coalescing_expression",
+            "type": "nil_literal",
             "named": true
           },
           {
@@ -3095,6 +3099,10 @@
         },
         {
           "type": "nil_coalescing_expression",
+          "named": true
+        },
+        {
+          "type": "nil_literal",
           "named": true
         },
         {
@@ -3442,11 +3450,11 @@
             "named": true
           },
           {
-            "type": "nil",
-            "named": false
+            "type": "nil_coalescing_expression",
+            "named": true
           },
           {
-            "type": "nil_coalescing_expression",
+            "type": "nil_literal",
             "named": true
           },
           {
@@ -3818,11 +3826,11 @@
             "named": true
           },
           {
-            "type": "nil",
-            "named": false
+            "type": "nil_coalescing_expression",
+            "named": true
           },
           {
-            "type": "nil_coalescing_expression",
+            "type": "nil_literal",
             "named": true
           },
           {
@@ -4103,6 +4111,10 @@
         },
         {
           "type": "nil_coalescing_expression",
+          "named": true
+        },
+        {
+          "type": "nil_literal",
           "named": true
         },
         {
@@ -4504,11 +4516,11 @@
             "named": true
           },
           {
-            "type": "nil",
-            "named": false
+            "type": "nil_coalescing_expression",
+            "named": true
           },
           {
-            "type": "nil_coalescing_expression",
+            "type": "nil_literal",
             "named": true
           },
           {
@@ -4976,11 +4988,11 @@
             "named": true
           },
           {
-            "type": "nil",
-            "named": false
+            "type": "nil_coalescing_expression",
+            "named": true
           },
           {
-            "type": "nil_coalescing_expression",
+            "type": "nil_literal",
             "named": true
           },
           {
@@ -5615,11 +5627,11 @@
             "named": true
           },
           {
-            "type": "nil",
-            "named": false
+            "type": "nil_coalescing_expression",
+            "named": true
           },
           {
-            "type": "nil_coalescing_expression",
+            "type": "nil_literal",
             "named": true
           },
           {
@@ -5987,11 +5999,11 @@
             "named": true
           },
           {
-            "type": "nil",
-            "named": false
+            "type": "nil_coalescing_expression",
+            "named": true
           },
           {
-            "type": "nil_coalescing_expression",
+            "type": "nil_literal",
             "named": true
           },
           {
@@ -6443,11 +6455,11 @@
             "named": true
           },
           {
-            "type": "nil",
-            "named": false
+            "type": "nil_coalescing_expression",
+            "named": true
           },
           {
-            "type": "nil_coalescing_expression",
+            "type": "nil_literal",
             "named": true
           },
           {
@@ -6803,11 +6815,11 @@
             "named": true
           },
           {
-            "type": "nil",
-            "named": false
+            "type": "nil_coalescing_expression",
+            "named": true
           },
           {
-            "type": "nil_coalescing_expression",
+            "type": "nil_literal",
             "named": true
           },
           {
@@ -7223,11 +7235,11 @@
             "named": true
           },
           {
-            "type": "nil",
-            "named": false
+            "type": "nil_coalescing_expression",
+            "named": true
           },
           {
-            "type": "nil_coalescing_expression",
+            "type": "nil_literal",
             "named": true
           },
           {
@@ -7579,11 +7591,11 @@
             "named": true
           },
           {
-            "type": "nil",
-            "named": false
+            "type": "nil_coalescing_expression",
+            "named": true
           },
           {
-            "type": "nil_coalescing_expression",
+            "type": "nil_literal",
             "named": true
           },
           {
@@ -7830,6 +7842,10 @@
           "named": true
         },
         {
+          "type": "nil_literal",
+          "named": true
+        },
+        {
           "type": "oct_literal",
           "named": true
         },
@@ -7981,6 +7997,10 @@
         },
         {
           "type": "multi_line_string_literal",
+          "named": true
+        },
+        {
+          "type": "nil_literal",
           "named": true
         },
         {
@@ -8264,11 +8284,11 @@
             "named": true
           },
           {
-            "type": "nil",
-            "named": false
+            "type": "nil_coalescing_expression",
+            "named": true
           },
           {
-            "type": "nil_coalescing_expression",
+            "type": "nil_literal",
             "named": true
           },
           {
@@ -8614,11 +8634,11 @@
             "named": true
           },
           {
-            "type": "nil",
-            "named": false
+            "type": "nil_coalescing_expression",
+            "named": true
           },
           {
-            "type": "nil_coalescing_expression",
+            "type": "nil_literal",
             "named": true
           },
           {
@@ -9116,6 +9136,10 @@
           "named": true
         },
         {
+          "type": "nil_literal",
+          "named": true
+        },
+        {
           "type": "oct_literal",
           "named": true
         },
@@ -9470,11 +9494,11 @@
             "named": true
           },
           {
-            "type": "nil",
-            "named": false
+            "type": "nil_coalescing_expression",
+            "named": true
           },
           {
-            "type": "nil_coalescing_expression",
+            "type": "nil_literal",
             "named": true
           },
           {
@@ -9830,11 +9854,11 @@
             "named": true
           },
           {
-            "type": "nil",
-            "named": false
+            "type": "nil_coalescing_expression",
+            "named": true
           },
           {
-            "type": "nil_coalescing_expression",
+            "type": "nil_literal",
             "named": true
           },
           {
@@ -10300,11 +10324,11 @@
             "named": true
           },
           {
-            "type": "nil",
-            "named": false
+            "type": "nil_coalescing_expression",
+            "named": true
           },
           {
-            "type": "nil_coalescing_expression",
+            "type": "nil_literal",
             "named": true
           },
           {
@@ -10626,6 +10650,10 @@
         },
         {
           "type": "nil_coalescing_expression",
+          "named": true
+        },
+        {
+          "type": "nil_literal",
           "named": true
         },
         {
@@ -11194,11 +11222,11 @@
             "named": true
           },
           {
-            "type": "nil",
-            "named": false
+            "type": "nil_coalescing_expression",
+            "named": true
           },
           {
-            "type": "nil_coalescing_expression",
+            "type": "nil_literal",
             "named": true
           },
           {
@@ -11566,11 +11594,11 @@
             "named": true
           },
           {
-            "type": "nil",
-            "named": false
+            "type": "nil_coalescing_expression",
+            "named": true
           },
           {
-            "type": "nil_coalescing_expression",
+            "type": "nil_literal",
             "named": true
           },
           {
@@ -12004,11 +12032,11 @@
             "named": true
           },
           {
-            "type": "nil",
-            "named": false
+            "type": "nil_coalescing_expression",
+            "named": true
           },
           {
-            "type": "nil_coalescing_expression",
+            "type": "nil_literal",
             "named": true
           },
           {
@@ -12422,11 +12450,11 @@
             "named": true
           },
           {
-            "type": "nil",
-            "named": false
+            "type": "nil_coalescing_expression",
+            "named": true
           },
           {
-            "type": "nil_coalescing_expression",
+            "type": "nil_literal",
             "named": true
           },
           {
@@ -13388,11 +13416,11 @@
             "named": true
           },
           {
-            "type": "nil",
-            "named": false
+            "type": "nil_coalescing_expression",
+            "named": true
           },
           {
-            "type": "nil_coalescing_expression",
+            "type": "nil_literal",
             "named": true
           },
           {
@@ -13965,11 +13993,11 @@
             "named": true
           },
           {
-            "type": "nil",
-            "named": false
+            "type": "nil_coalescing_expression",
+            "named": true
           },
           {
-            "type": "nil_coalescing_expression",
+            "type": "nil_literal",
             "named": true
           },
           {
@@ -14476,11 +14504,11 @@
             "named": true
           },
           {
-            "type": "nil",
-            "named": false
+            "type": "nil_coalescing_expression",
+            "named": true
           },
           {
-            "type": "nil_coalescing_expression",
+            "type": "nil_literal",
             "named": true
           },
           {
@@ -14836,11 +14864,11 @@
             "named": true
           },
           {
-            "type": "nil",
-            "named": false
+            "type": "nil_coalescing_expression",
+            "named": true
           },
           {
-            "type": "nil_coalescing_expression",
+            "type": "nil_literal",
             "named": true
           },
           {
@@ -15453,11 +15481,11 @@
             "named": true
           },
           {
-            "type": "nil",
-            "named": false
+            "type": "nil_coalescing_expression",
+            "named": true
           },
           {
-            "type": "nil_coalescing_expression",
+            "type": "nil_literal",
             "named": true
           },
           {
@@ -15877,11 +15905,11 @@
             "named": true
           },
           {
-            "type": "nil",
-            "named": false
+            "type": "nil_coalescing_expression",
+            "named": true
           },
           {
-            "type": "nil_coalescing_expression",
+            "type": "nil_literal",
             "named": true
           },
           {
@@ -16179,6 +16207,10 @@
         },
         {
           "type": "nil_coalescing_expression",
+          "named": true
+        },
+        {
+          "type": "nil_literal",
           "named": true
         },
         {
@@ -16933,11 +16965,11 @@
             "named": true
           },
           {
-            "type": "nil",
-            "named": false
+            "type": "nil_coalescing_expression",
+            "named": true
           },
           {
-            "type": "nil_coalescing_expression",
+            "type": "nil_literal",
             "named": true
           },
           {
@@ -17389,11 +17421,11 @@
             "named": true
           },
           {
-            "type": "nil",
-            "named": false
+            "type": "nil_coalescing_expression",
+            "named": true
           },
           {
-            "type": "nil_coalescing_expression",
+            "type": "nil_literal",
             "named": true
           },
           {
@@ -17945,11 +17977,11 @@
             "named": true
           },
           {
-            "type": "nil",
-            "named": false
+            "type": "nil_coalescing_expression",
+            "named": true
           },
           {
-            "type": "nil_coalescing_expression",
+            "type": "nil_literal",
             "named": true
           },
           {
@@ -18313,11 +18345,11 @@
             "named": true
           },
           {
-            "type": "nil",
-            "named": false
+            "type": "nil_coalescing_expression",
+            "named": true
           },
           {
-            "type": "nil_coalescing_expression",
+            "type": "nil_literal",
             "named": true
           },
           {
@@ -18722,11 +18754,11 @@
             "named": true
           },
           {
-            "type": "nil",
-            "named": false
+            "type": "nil_coalescing_expression",
+            "named": true
           },
           {
-            "type": "nil_coalescing_expression",
+            "type": "nil_literal",
             "named": true
           },
           {
@@ -19106,11 +19138,11 @@
             "named": true
           },
           {
-            "type": "nil",
-            "named": false
+            "type": "nil_coalescing_expression",
+            "named": true
           },
           {
-            "type": "nil_coalescing_expression",
+            "type": "nil_literal",
             "named": true
           },
           {
@@ -19456,11 +19488,11 @@
             "named": true
           },
           {
-            "type": "nil",
-            "named": false
+            "type": "nil_coalescing_expression",
+            "named": true
           },
           {
-            "type": "nil_coalescing_expression",
+            "type": "nil_literal",
             "named": true
           },
           {
@@ -19879,11 +19911,11 @@
             "named": true
           },
           {
-            "type": "nil",
-            "named": false
+            "type": "nil_coalescing_expression",
+            "named": true
           },
           {
-            "type": "nil_coalescing_expression",
+            "type": "nil_literal",
             "named": true
           },
           {
@@ -20235,11 +20267,11 @@
             "named": true
           },
           {
-            "type": "nil",
-            "named": false
+            "type": "nil_coalescing_expression",
+            "named": true
           },
           {
-            "type": "nil_coalescing_expression",
+            "type": "nil_literal",
             "named": true
           },
           {
@@ -20806,6 +20838,10 @@
           "named": true
         },
         {
+          "type": "nil_literal",
+          "named": true
+        },
+        {
           "type": "oct_literal",
           "named": true
         },
@@ -21062,6 +21098,10 @@
         },
         {
           "type": "nil_coalescing_expression",
+          "named": true
+        },
+        {
+          "type": "nil_literal",
           "named": true
         },
         {
@@ -21422,11 +21462,11 @@
             "named": true
           },
           {
-            "type": "nil",
-            "named": false
+            "type": "nil_coalescing_expression",
+            "named": true
           },
           {
-            "type": "nil_coalescing_expression",
+            "type": "nil_literal",
             "named": true
           },
           {
@@ -21877,11 +21917,11 @@
             "named": true
           },
           {
-            "type": "nil",
-            "named": false
+            "type": "nil_coalescing_expression",
+            "named": true
           },
           {
-            "type": "nil_coalescing_expression",
+            "type": "nil_literal",
             "named": true
           },
           {
@@ -22258,11 +22298,11 @@
             "named": true
           },
           {
-            "type": "nil",
-            "named": false
+            "type": "nil_coalescing_expression",
+            "named": true
           },
           {
-            "type": "nil_coalescing_expression",
+            "type": "nil_literal",
             "named": true
           },
           {
@@ -22844,11 +22884,11 @@
             "named": true
           },
           {
-            "type": "nil",
-            "named": false
+            "type": "nil_coalescing_expression",
+            "named": true
           },
           {
-            "type": "nil_coalescing_expression",
+            "type": "nil_literal",
             "named": true
           },
           {
@@ -23547,11 +23587,11 @@
             "named": true
           },
           {
-            "type": "nil",
-            "named": false
+            "type": "nil_coalescing_expression",
+            "named": true
           },
           {
-            "type": "nil_coalescing_expression",
+            "type": "nil_literal",
             "named": true
           },
           {
@@ -23911,11 +23951,11 @@
             "named": true
           },
           {
-            "type": "nil",
-            "named": false
+            "type": "nil_coalescing_expression",
+            "named": true
           },
           {
-            "type": "nil_coalescing_expression",
+            "type": "nil_literal",
             "named": true
           },
           {
@@ -24412,11 +24452,11 @@
             "named": true
           },
           {
-            "type": "nil",
-            "named": false
+            "type": "nil_coalescing_expression",
+            "named": true
           },
           {
-            "type": "nil_coalescing_expression",
+            "type": "nil_literal",
             "named": true
           },
           {
@@ -24796,6 +24836,10 @@
           "named": true
         },
         {
+          "type": "nil_literal",
+          "named": true
+        },
+        {
           "type": "oct_literal",
           "named": true
         },
@@ -25098,6 +25142,10 @@
         },
         {
           "type": "nil_coalescing_expression",
+          "named": true
+        },
+        {
+          "type": "nil_literal",
           "named": true
         },
         {
@@ -25406,6 +25454,10 @@
         },
         {
           "type": "nil_coalescing_expression",
+          "named": true
+        },
+        {
+          "type": "nil_literal",
           "named": true
         },
         {
@@ -25773,11 +25825,11 @@
             "named": true
           },
           {
-            "type": "nil",
-            "named": false
+            "type": "nil_coalescing_expression",
+            "named": true
           },
           {
-            "type": "nil_coalescing_expression",
+            "type": "nil_literal",
             "named": true
           },
           {
@@ -26220,6 +26272,10 @@
           "named": true
         },
         {
+          "type": "nil_literal",
+          "named": true
+        },
+        {
           "type": "oct_literal",
           "named": true
         },
@@ -26586,11 +26642,11 @@
             "named": true
           },
           {
-            "type": "nil",
-            "named": false
+            "type": "nil_coalescing_expression",
+            "named": true
           },
           {
-            "type": "nil_coalescing_expression",
+            "type": "nil_literal",
             "named": true
           },
           {
@@ -26952,11 +27008,11 @@
             "named": true
           },
           {
-            "type": "nil",
-            "named": false
+            "type": "nil_coalescing_expression",
+            "named": true
           },
           {
-            "type": "nil_coalescing_expression",
+            "type": "nil_literal",
             "named": true
           },
           {
@@ -27302,11 +27358,11 @@
             "named": true
           },
           {
-            "type": "nil",
-            "named": false
+            "type": "nil_coalescing_expression",
+            "named": true
           },
           {
-            "type": "nil_coalescing_expression",
+            "type": "nil_literal",
             "named": true
           },
           {
@@ -27652,11 +27708,11 @@
             "named": true
           },
           {
-            "type": "nil",
-            "named": false
+            "type": "nil_coalescing_expression",
+            "named": true
           },
           {
-            "type": "nil_coalescing_expression",
+            "type": "nil_literal",
             "named": true
           },
           {
@@ -28081,11 +28137,11 @@
             "named": true
           },
           {
-            "type": "nil",
-            "named": false
+            "type": "nil_coalescing_expression",
+            "named": true
           },
           {
-            "type": "nil_coalescing_expression",
+            "type": "nil_literal",
             "named": true
           },
           {
@@ -28462,11 +28518,11 @@
             "named": true
           },
           {
-            "type": "nil",
-            "named": false
+            "type": "nil_coalescing_expression",
+            "named": true
           },
           {
-            "type": "nil_coalescing_expression",
+            "type": "nil_literal",
             "named": true
           },
           {
@@ -29753,11 +29809,11 @@
             "named": true
           },
           {
-            "type": "nil",
-            "named": false
+            "type": "nil_coalescing_expression",
+            "named": true
           },
           {
-            "type": "nil_coalescing_expression",
+            "type": "nil_literal",
             "named": true
           },
           {
@@ -30069,6 +30125,10 @@
           "named": true
         },
         {
+          "type": "nil_literal",
+          "named": true
+        },
+        {
           "type": "oct_literal",
           "named": true
         },
@@ -30305,6 +30365,10 @@
         },
         {
           "type": "nil_coalescing_expression",
+          "named": true
+        },
+        {
+          "type": "nil_literal",
           "named": true
         },
         {
@@ -30549,6 +30613,10 @@
         },
         {
           "type": "nil_coalescing_expression",
+          "named": true
+        },
+        {
+          "type": "nil_literal",
           "named": true
         },
         {
@@ -30969,11 +31037,11 @@
             "named": true
           },
           {
-            "type": "nil",
-            "named": false
+            "type": "nil_coalescing_expression",
+            "named": true
           },
           {
-            "type": "nil_coalescing_expression",
+            "type": "nil_literal",
             "named": true
           },
           {
@@ -31759,8 +31827,8 @@
     "named": false
   },
   {
-    "type": "nil",
-    "named": false
+    "type": "nil_literal",
+    "named": true
   },
   {
     "type": "nonisolated",

--- a/test/corpus/expressions.txt
+++ b/test/corpus/expressions.txt
@@ -211,6 +211,32 @@ foo() ? bar() : baz()
         (value_arguments)))))
 
 ================================================================================
+Ternary expression with nil arms
+================================================================================
+
+false ? "foo" : nil
+false ? nil : "bar"
+false ? nil : nil
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (ternary_expression
+    (boolean_literal)
+    (line_string_literal
+      (line_str_text))
+    (nil_literal))
+  (ternary_expression
+    (boolean_literal)
+    (nil_literal)
+    (line_string_literal
+      (line_str_text)))
+  (ternary_expression
+    (boolean_literal)
+    (nil_literal)
+    (nil_literal)))
+
+================================================================================
 Multiple expressions on one line using semicolons
 ================================================================================
 
@@ -636,7 +662,8 @@ let result: MyEnumType = condition ? .someEnumCase : .someOtherEnum
     (ternary_expression
       (tuple_expression
         (equality_expression
-          (simple_identifier)))
+          (simple_identifier)
+          (nil_literal)))
       (array_literal
         (prefix_expression
           (simple_identifier)))

--- a/test/corpus/functions.txt
+++ b/test/corpus/functions.txt
@@ -216,7 +216,8 @@ func returnGetsImplicitlyUnwrapped() -> String! {
       (type_identifier))
     (function_body
       (statements
-        (control_transfer_statement)))))
+        (control_transfer_statement
+          (nil_literal))))))
 
 ================================================================================
 Variadic functions

--- a/test/corpus/literals.txt
+++ b/test/corpus/literals.txt
@@ -242,7 +242,8 @@ let _ = nil
   (property_declaration
     (value_binding_pattern)
     (pattern
-      (wildcard_pattern))))
+      (wildcard_pattern))
+    (nil_literal)))
 
 ================================================================================
 Raw strings

--- a/test/corpus/statements.txt
+++ b/test/corpus/statements.txt
@@ -931,6 +931,7 @@ If try
       (equality_expression
         (simple_identifier)
         (conjunction_expression
+          (nil_literal)
           (conjunction_expression
             (simple_identifier)
             (prefix_expression
@@ -1065,7 +1066,8 @@ guard case let size: Int = variable.size else {
         (simple_identifier)))
     (else)
     (statements
-      (control_transfer_statement))))
+      (control_transfer_statement
+        (nil_literal)))))
 
 ================================================================================
 Availability conditions

--- a/test/corpus/types.txt
+++ b/test/corpus/types.txt
@@ -267,7 +267,8 @@ let closure = { (v: AnyObject??) -> String? in
           (user_type
             (type_identifier))))
       (statements
-        (control_transfer_statement)))))
+        (control_transfer_statement
+          (nil_literal))))))
 
 ================================================================================
 Double optional array element in lambda parameter (ReactKit regression)
@@ -296,7 +297,8 @@ let closure = { (values: [AnyObject??], _) -> String? in nil }
         (optional_type
           (user_type
             (type_identifier))))
-      (statements))))
+      (statements
+        (nil_literal)))))
 
 ================================================================================
 Implicitly unwrapped optional types


### PR DESCRIPTION
## Problem

`nil` was defined as an anonymous terminal (bare string `"nil"`) inside `_basic_literal`. In tree-sitter, anonymous nodes are hidden from the standard parse output and filtered by most language bindings when walking fields. This meant that even though the parser correctly placed `nil` in the `if_true`/`if_false` slots of a ternary expression, callers using `child_by_field_name` or the normal S-expression output saw nothing there:

```swift
false ? "foo" : nil   // if_false field appeared empty
false ? nil : "bar"   // if_true field appeared empty
```

## Fix

Introduce a named `nil_literal` rule, mirroring the existing `boolean_literal` pattern:

```js
nil_literal: ($) => "nil",
```

Replace the bare `"nil"` in `_basic_literal` with `$.nil_literal`. `nil` is now a named node that appears in parse output and is accessible via field APIs:

```
(ternary_expression
  condition: (boolean_literal)
  if_true: (line_string_literal ...)
  if_false: (nil_literal))         ← now visible
```

Update `highlights.scm` to capture `(nil_literal) @constant.builtin` instead of the anonymous token, and update all corpus tests that contain `nil` to reflect the new named node.

## Test plan

- [x] `npm run build` — no new warnings
- [x] `npx tree-sitter test` — all 240 tests pass (6 existing tests auto-updated with `-u`, new ternary-nil corpus test added)
- [x] `npm run ci` (Prettier) — passes

Closes #303

🤖 Generated with [Claude Code](https://claude.ai/claude-code)