### PR TITLE
Fix prefix operators binding to navigation chain, not just base identifier (#272)

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -46,7 +46,7 @@ const PRECS = {
   do: -1,
   fully_open_range: -1,
   range: -1,
-  navigation: -1,
+  navigation: 12,
   expr: -1,
   ty: -1,
   call: -2,

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -2135,7 +2135,7 @@
     },
     "navigation_expression": {
       "type": "PREC_LEFT",
-      "value": -1,
+      "value": 12,
       "content": {
         "type": "SEQ",
         "members": [

--- a/test/corpus/expressions.txt
+++ b/test/corpus/expressions.txt
@@ -1179,6 +1179,42 @@ for try await value in values {
               (simple_identifier))))))))
 
 ================================================================================
+Prefix operator binds to navigation chain, not just the base (#272)
+================================================================================
+
+!foo.bar
+!foo.bar.baz
+!Enum.case.variable
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (prefix_expression
+    (bang)
+    (navigation_expression
+      (simple_identifier)
+      (navigation_suffix
+        (simple_identifier))))
+  (prefix_expression
+    (bang)
+    (navigation_expression
+      (navigation_expression
+        (simple_identifier)
+        (navigation_suffix
+          (simple_identifier)))
+      (navigation_suffix
+        (simple_identifier))))
+  (prefix_expression
+    (bang)
+    (navigation_expression
+      (navigation_expression
+        (simple_identifier)
+        (navigation_suffix
+          (simple_identifier)))
+      (navigation_suffix
+        (simple_identifier)))))
+
+================================================================================
 Negation at the start of a line
 ================================================================================
 

--- a/test/corpus/literals.txt
+++ b/test/corpus/literals.txt
@@ -573,21 +573,21 @@ let y = array.reduce(1, /) + otherArray.reduce(1, /)
     (pattern
       (simple_identifier))
     (call_expression
-      (navigation_expression
-        (additive_expression
-          (call_expression
-            (navigation_expression
-              (simple_identifier)
-              (navigation_suffix
-                (simple_identifier)))
-            (call_suffix
-              (value_arguments
-                (value_argument
-                  (integer_literal))
-                (value_argument))))
-          (simple_identifier))
-        (navigation_suffix
-          (simple_identifier)))
+      (additive_expression
+        (call_expression
+          (navigation_expression
+            (simple_identifier)
+            (navigation_suffix
+              (simple_identifier)))
+          (call_suffix
+            (value_arguments
+              (value_argument
+                (integer_literal))
+              (value_argument))))
+        (navigation_expression
+          (simple_identifier)
+          (navigation_suffix
+            (simple_identifier))))
       (call_suffix
         (value_arguments
           (value_argument


### PR DESCRIPTION
## Problem

`!Enum.case.variable` was parsed as `(!Enum).case.variable` — the `!` only applied to `Enum`, with the navigation chain tacked on outside the prefix expression. The same bug affected all prefix operators (`-`, `~`, etc.) and binary operators on their RHS.

Root cause: `PRECS.navigation` was `-1` (the lowest precedence), so in any shift-reduce conflict between "reduce the current expression" and "shift `.` to extend into a navigation", reduce always won.

## Fix

Raise `PRECS.navigation` from `-1` to `12` (above `multiplication: 11`, the highest binary operator). In Swift, member access is a postfix operation and binds tighter than all prefix and binary operators — this precedence reflects that.

```
Before:   !foo.bar          =>  (!foo).bar
After:    !foo.bar          =>  !(foo.bar)   ✓

Before:   !Enum.case.var    =>  ((!Enum).case).var
After:    !Enum.case.var    =>  !(Enum.case.var)   ✓

Before:   a - b.c           =>  (a-b).c
After:    a - b.c           =>  a-(b.c)   ✓  (correct Swift semantics)
```

`PRECS.navigation` is used in exactly one place in the grammar (`navigation_expression`), so the change is contained.

## Test plan

- [x] `npm run build` — no new warnings
- [x] `npx tree-sitter test` — all 241 tests pass; one existing corpus test (`Unapplied / that is not a regex literal`) updated: the imperfect parse of `array.reduce(1,/) + otherArray.reduce(1,/)` changes form, but the underlying `/`-scanner ambiguity is a pre-existing limitation unrelated to this change
- [x] `npm run ci` (Prettier) — passes
- [x] `bash scripts/top-repos.sh` — all 52 top repositories parse without new failures

Closes #272

🤖 Generated with [Claude Code](https://claude.ai/claude-code)