### PR TITLE
Fix `if let x = try await f() { ... }` parsing the block as a trailing closure

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -121,6 +121,9 @@ module.exports = grammar({
     // all the options and pick the best one that doesn't error out.
     [$.try_expression, $._unary_expression],
     [$.try_expression, $._expression],
+    // `try await foo()!` is ambiguous between `(try await foo())!` and `try (await foo())!` until the postfix
+    // operator is consumed; parse both and pick the survivor.
+    [$.try_expression, $._primary_expression],
     // await {expression} has the same special cases as `try`.
     [$.await_expression, $._unary_expression],
     [$.await_expression, $._expression],
@@ -852,6 +855,10 @@ module.exports = grammar({
               prec.right(-2, $._expression),
               prec.left(0, $._binary_expression),
               prec.left(0, $.call_expression),
+              // Also special-case `try await foo()`: without this, the `await_expression` is only reachable through
+              // the low-precedence `_expression` branch, so `if let x = try await foo() { ... }` resolves the `{` as
+              // a trailing closure on `foo()` instead of the if-body.
+              prec.left(0, $.await_expression),
               // Similarly special case the ternary expression, where `try` may come earlier than it is actually needed.
               // When the parser just encounters some identifier after a `try`, it should prefer the `call_expression` (so
               // this should be lower in priority than that), but when we encounter an ambiguous expression that might be

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -3334,6 +3334,14 @@
                   }
                 },
                 {
+                  "type": "PREC_LEFT",
+                  "value": 0,
+                  "content": {
+                    "type": "SYMBOL",
+                    "name": "await_expression"
+                  }
+                },
+                {
                   "type": "PREC_DYNAMIC",
                   "value": 1,
                   "content": {
@@ -11428,6 +11436,10 @@
     [
       "try_expression",
       "_expression"
+    ],
+    [
+      "try_expression",
+      "_primary_expression"
     ],
     [
       "await_expression",

--- a/test/corpus/statements.txt
+++ b/test/corpus/statements.txt
@@ -801,6 +801,64 @@ func doSomething() {
           (simple_identifier))))))
 
 ================================================================================
+If let with try await function call
+================================================================================
+
+func doSomething() async throws {
+    if let a = try await Foo.getValue() {
+        return a
+    }
+    guard let b = try await Foo.getValue() else {
+        return defaultValue
+    }
+    return b
+}
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (function_declaration
+    (simple_identifier)
+    (throws)
+    (function_body
+      (statements
+        (if_statement
+          (value_binding_pattern)
+          (simple_identifier)
+          (try_expression
+            (try_operator)
+            (await_expression
+              (call_expression
+                (navigation_expression
+                  (simple_identifier)
+                  (navigation_suffix
+                    (simple_identifier)))
+                (call_suffix
+                  (value_arguments)))))
+          (statements
+            (control_transfer_statement
+              (simple_identifier))))
+        (guard_statement
+          (value_binding_pattern)
+          (simple_identifier)
+          (try_expression
+            (try_operator)
+            (await_expression
+              (call_expression
+                (navigation_expression
+                  (simple_identifier)
+                  (navigation_suffix
+                    (simple_identifier)))
+                (call_suffix
+                  (value_arguments)))))
+          (else)
+          (statements
+            (control_transfer_statement
+              (simple_identifier))))
+        (control_transfer_statement
+          (simple_identifier))))))
+
+================================================================================
 Compound if let
 ================================================================================
 


### PR DESCRIPTION
Found this while using this within DiffTastic in one of my projects.

OK:

`if let x = try f()`
`if let x = await f()`

Fails:

`if let r = try await f() { g() }`

(cascades into ERROR nodes for the rest of the enclosing scope)

`try_expression` prefers direct calls (`prec.left(0, $.call_expression)`), which is what steers an ambiguous `{` toward the if-body instead of a trailing closure. But with `try await f()`, the `await_expression` was only reachable through the low-precedence `_expression` branch, so the disambiguation was skipped and the if-body was consumed as a trailing closure on `f()`.


Give `await_expression` the same treatment as `call_expression` inside `try_expression`, and declare the resulting `[$.try_expression, $._primary_expression]` conflict (`try await f()!` is ambiguous until the postfix operator is consumed).

Disclaimer: Claude found and fixed this bug. 