### PR TITLE
Fix undefined 32-bit shift in OP_SYMBOL_SUPPRESSOR on LLP64 targets

### DIFF
--- a/src/scanner.c
+++ b/src/scanner.c
@@ -172,7 +172,7 @@ const uint64_t OP_SYMBOL_SUPPRESSOR[OPERATOR_COUNT] = {
     0, // EQ_EQ,
     0, // PLUS_THEN_WS,
     0, // MINUS_THEN_WS,
-    1UL << FAKE_TRY_BANG, // BANG,
+    1ULL << FAKE_TRY_BANG, // BANG,
         0, // THROWS_KEYWORD,
         0, // RETHROWS_KEYWORD,
         0, // DEFAULT_KEYWORD,


### PR DESCRIPTION
`OP_SYMBOL_SUPPRESSOR` is a `uint64_t` table, but the `BANG` entry is initialized with `1UL << FAKE_TRY_BANG`. `FAKE_TRY_BANG` is the last member of `enum TokenType`, so its value is 32 - and on LLP64 targets (Windows with MSVC or clang), `unsigned long` is 32 bits wide, which makes this a shift by the full width of the type: undefined behavior.

clang reports it when targeting Windows:

```
src/scanner.c:175:9: warning: shift count >= width of type [-Wshift-count-overflow]
  175 |     1UL << FAKE_TRY_BANG, // BANG,
```

In practice x86 masks the shift count, so the initializer evaluates to `1` instead of `1ULL << 32` - the suppressor mask for `BANG` ends up pointing at the `BLOCK_COMMENT` bit rather than `FAKE_TRY_BANG`, which affects operator suppression around postfix `!` / `try!` in Windows builds.

The read side already does this correctly (`suppressing_symbols & 1ULL << suppressor` in `eat_operators`), so this just brings the initializer in line with it.

Verified that the `-Wshift-count-overflow` warning is gone when compiling `scanner.c` for x86_64-windows.