### PR TITLE
Fix optional cast nil-coalescing

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -223,6 +223,7 @@ module.exports = grammar({
     $._conjunction_operator_custom,
     $._disjunction_operator_custom,
     $._nil_coalescing_operator_custom,
+    $._double_optional_custom,
     $._eq_custom,
     $._eq_eq_custom,
     $._plus_then_ws,
@@ -496,11 +497,9 @@ module.exports = grammar({
           repeat1(
             choice(
               alias($._immediate_quest, "?"),
-              // The external scanner always tokenizes `??` as NIL_COALESCING_OPERATOR.
-              // In type position (e.g. `(v: AnyObject??)`) that single token represents
-              // two consecutive optional markers; accept it here since nil-coalescing is
-              // an expression-only construct and cannot appear in a type.
-              alias($._nil_coalescing_operator, "??")
+              // The scanner keeps an immediate `??` type suffix distinct from a
+              // nil-coalescing operator that follows whitespace.
+              alias($._double_optional, "??")
             )
           )
         )
@@ -1730,6 +1729,7 @@ module.exports = grammar({
     _disjunction_operator: ($) => alias($._disjunction_operator_custom, "||"),
     _nil_coalescing_operator: ($) =>
       alias($._nil_coalescing_operator_custom, "??"),
+    _double_optional: ($) => alias($._double_optional_custom, "??"),
     _as: ($) => alias($._as_custom, "as"),
     _as_quest: ($) => alias($._as_quest_custom, "as?"),
     _as_bang: ($) => alias($._as_bang_custom, "as!"),

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -1702,7 +1702,7 @@
                   "type": "ALIAS",
                   "content": {
                     "type": "SYMBOL",
-                    "name": "_nil_coalescing_operator"
+                    "name": "_double_optional"
                   },
                   "named": false,
                   "value": "??"
@@ -8484,6 +8484,15 @@
       "named": false,
       "value": "??"
     },
+    "_double_optional": {
+      "type": "ALIAS",
+      "content": {
+        "type": "SYMBOL",
+        "name": "_double_optional_custom"
+      },
+      "named": false,
+      "value": "??"
+    },
     "_as": {
       "type": "ALIAS",
       "content": {
@@ -11579,6 +11588,10 @@
     {
       "type": "SYMBOL",
       "name": "_nil_coalescing_operator_custom"
+    },
+    {
+      "type": "SYMBOL",
+      "name": "_double_optional_custom"
     },
     {
       "type": "SYMBOL",

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -2,7 +2,7 @@
 #include <string.h>
 #include <wctype.h>
 
-#define TOKEN_COUNT 33
+#define TOKEN_COUNT 34
 
 enum TokenType {
     BLOCK_COMMENT,
@@ -16,6 +16,7 @@ enum TokenType {
     CONJUNCTION_OPERATOR,
     DISJUNCTION_OPERATOR,
     NIL_COALESCING_OPERATOR,
+    DOUBLE_OPTIONAL,
     EQUAL_SIGN,
     EQ_EQ,
     PLUS_THEN_WS,
@@ -438,7 +439,10 @@ static uint32_t collect_fixed_operator_candidates(
         }
         break;
     case '?':
-        if (valid_symbols[NIL_COALESCING_OPERATOR]) {
+        if (
+            valid_symbols[NIL_COALESCING_OPERATOR] ||
+            valid_symbols[DOUBLE_OPTIONAL]
+        ) {
             candidates[count++] = OPERATOR_INDEX_NIL_COALESCING;
         }
         break;
@@ -514,6 +518,7 @@ static bool eat_operators(
     TSLexer *lexer,
     const bool *valid_symbols,
     bool mark_end,
+    bool token_is_immediate,
     const int32_t prior_char,
     enum TokenType *symbol_result
 ) {
@@ -672,7 +677,19 @@ static bool eat_operators(
                 }
             }
         }
-        *symbol_result = OP_SYMBOLS[full_match];
+        enum TokenType matched_symbol = OP_SYMBOLS[full_match];
+        if (
+            matched_symbol == NIL_COALESCING_OPERATOR &&
+            valid_symbols[DOUBLE_OPTIONAL]
+        ) {
+            if (!token_is_immediate && !valid_symbols[NIL_COALESCING_OPERATOR]) {
+                return false;
+            }
+            matched_symbol = token_is_immediate
+                             ? DOUBLE_OPTIONAL
+                             : NIL_COALESCING_OPERATOR;
+        }
+        *symbol_result = matched_symbol;
         return true;
     }
 
@@ -822,6 +839,7 @@ static enum ParseDirective eat_whitespace(
                                 lexer,
                                 valid_symbols,
                                 /* mark_end */ false,
+                                /* token_is_immediate */ false,
                                 '\0',
                                 &operator_result
                             );
@@ -1033,6 +1051,7 @@ bool tree_sitter_swift_external_scanner_scan(
     struct ScannerState *state = (struct ScannerState *)payload;
 
     // Consume any whitespace at the start.
+    bool token_is_immediate = !should_treat_as_wspace(lexer->lookahead);
     enum TokenType ws_result;
     enum ParseDirective ws_directive = eat_whitespace(lexer, valid_symbols, &ws_result);
     if (ws_directive == STOP_PARSING_TOKEN_FOUND) {
@@ -1064,6 +1083,7 @@ bool tree_sitter_swift_external_scanner_scan(
                             lexer,
                             valid_symbols,
                             /* mark_end */ !has_ws_result,
+                            token_is_immediate,
                             comment == CONTINUE_PARSING_SLASH_CONSUMED ? '/' : '\0',
                             &operator_result
                         );

--- a/test/corpus/types.txt
+++ b/test/corpus/types.txt
@@ -26,6 +26,46 @@ something as! A
       (type_identifier))))
 
 ================================================================================
+Optional casts followed by nil-coalescing
+================================================================================
+
+let x = y as? String ?? "z"
+let flag = d.get() as? Bool ?? true
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (property_declaration
+    (value_binding_pattern)
+    (pattern
+      (simple_identifier))
+    (nil_coalescing_expression
+      (as_expression
+        (simple_identifier)
+        (as_operator)
+        (user_type
+          (type_identifier)))
+      (line_string_literal
+        (line_str_text))))
+  (property_declaration
+    (value_binding_pattern)
+    (pattern
+      (simple_identifier))
+    (nil_coalescing_expression
+      (as_expression
+        (call_expression
+          (navigation_expression
+            (simple_identifier)
+            (navigation_suffix
+              (simple_identifier)))
+          (call_suffix
+            (value_arguments)))
+        (as_operator)
+        (user_type
+          (type_identifier)))
+      (boolean_literal))))
+
+================================================================================
 Nested types
 ================================================================================
 


### PR DESCRIPTION
https://github.com/alex-pinkus/tree-sitter-swift/pull/578 caused a regression parsing nil coalescing expressions after conditional type casts. This change distinguishes immediate double-optional type suffixes from whitespace-separated nil-coalescing operators, preserving `Type??` while restoring `as? T ?? fallback` parsing.

Fixes https://github.com/alex-pinkus/tree-sitter-swift/issues/597
Fixes https://github.com/alex-pinkus/tree-sitter-swift/issues/610
