### PR TITLE
Fix where clauses on comma-separated switch case patterns

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -1132,11 +1132,13 @@ module.exports = grammar({
         choice(
           seq(
             "case",
-            seq(
-              $.switch_pattern,
-              optional(seq($.where_keyword, $._expression))
-            ),
-            repeat(seq(",", $.switch_pattern))
+            sep1(
+              seq(
+                $.switch_pattern,
+                optional(seq($.where_keyword, $._expression))
+              ),
+              ","
+            )
           ),
           $.default_keyword
         ),

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -4844,47 +4844,78 @@
                   "type": "SEQ",
                   "members": [
                     {
-                      "type": "SYMBOL",
-                      "name": "switch_pattern"
-                    },
-                    {
-                      "type": "CHOICE",
+                      "type": "SEQ",
                       "members": [
                         {
-                          "type": "SEQ",
-                          "members": [
-                            {
-                              "type": "SYMBOL",
-                              "name": "where_keyword"
-                            },
-                            {
-                              "type": "SYMBOL",
-                              "name": "_expression"
-                            }
-                          ]
+                          "type": "SYMBOL",
+                          "name": "switch_pattern"
                         },
                         {
-                          "type": "BLANK"
+                          "type": "CHOICE",
+                          "members": [
+                            {
+                              "type": "SEQ",
+                              "members": [
+                                {
+                                  "type": "SYMBOL",
+                                  "name": "where_keyword"
+                                },
+                                {
+                                  "type": "SYMBOL",
+                                  "name": "_expression"
+                                }
+                              ]
+                            },
+                            {
+                              "type": "BLANK"
+                            }
+                          ]
                         }
                       ]
+                    },
+                    {
+                      "type": "REPEAT",
+                      "content": {
+                        "type": "SEQ",
+                        "members": [
+                          {
+                            "type": "STRING",
+                            "value": ","
+                          },
+                          {
+                            "type": "SEQ",
+                            "members": [
+                              {
+                                "type": "SYMBOL",
+                                "name": "switch_pattern"
+                              },
+                              {
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "SEQ",
+                                    "members": [
+                                      {
+                                        "type": "SYMBOL",
+                                        "name": "where_keyword"
+                                      },
+                                      {
+                                        "type": "SYMBOL",
+                                        "name": "_expression"
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "BLANK"
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
                     }
                   ]
-                },
-                {
-                  "type": "REPEAT",
-                  "content": {
-                    "type": "SEQ",
-                    "members": [
-                      {
-                        "type": "STRING",
-                        "value": ","
-                      },
-                      {
-                        "type": "SYMBOL",
-                        "name": "switch_pattern"
-                      }
-                    ]
-                  }
                 }
               ]
             },

--- a/test/corpus/statements.txt
+++ b/test/corpus/statements.txt
@@ -402,6 +402,53 @@ case let .isExecutable(path?):
               (simple_identifier))))))))
 
 ================================================================================
+Switch patterns with individual where clauses
+================================================================================
+
+switch value {
+case .a where first, .b where second:
+    break
+case .c, .d where condition:
+    break
+default:
+    break
+}
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (switch_statement
+    (simple_identifier)
+    (switch_entry
+      (switch_pattern
+        (pattern
+          (simple_identifier)))
+      (where_keyword)
+      (simple_identifier)
+      (switch_pattern
+        (pattern
+          (simple_identifier)))
+      (where_keyword)
+      (simple_identifier)
+      (statements
+        (control_transfer_statement)))
+    (switch_entry
+      (switch_pattern
+        (pattern
+          (simple_identifier)))
+      (switch_pattern
+        (pattern
+          (simple_identifier)))
+      (where_keyword)
+      (simple_identifier)
+      (statements
+        (control_transfer_statement)))
+    (switch_entry
+      (default_keyword)
+      (statements
+        (control_transfer_statement)))))
+
+================================================================================
 Switch with extra parentheses
 ================================================================================
 


### PR DESCRIPTION
### Summary

- Allow every comma-separated switch case pattern to have its own `where` clause.
- Use the existing `sep1` helper to define the pattern rule once.
- Add corpus coverage for multiple guarded patterns and a subsequent-only guard.

### Validation

- `npm run ci`
- `tree-sitter test`
- `cargo test`