### PR TITLE
Fix continued bitwise expressions

### DIFF
--- a/src/scanner.c
+++ b/src/scanner.c
@@ -226,9 +226,6 @@ static bool is_cross_semi_token(enum TokenType op) {
     switch(op) {
     case ARROW_OPERATOR:
     case DOT_OPERATOR:
-    case CONJUNCTION_OPERATOR:
-    case DISJUNCTION_OPERATOR:
-    case NIL_COALESCING_OPERATOR:
     case EQUAL_SIGN:
     case EQ_EQ:
     case PLUS_THEN_WS:
@@ -251,8 +248,10 @@ static bool is_cross_semi_token(enum TokenType op) {
     }
 }
 
-#define NON_CONSUMING_CROSS_SEMI_CHAR_COUNT 3
-const uint32_t NON_CONSUMING_CROSS_SEMI_CHARS[NON_CONSUMING_CROSS_SEMI_CHAR_COUNT] = { '?', ':', '{' };
+#define NON_CONSUMING_CROSS_SEMI_CHAR_COUNT 8
+const uint32_t NON_CONSUMING_CROSS_SEMI_CHARS[NON_CONSUMING_CROSS_SEMI_CHAR_COUNT] = {
+    '?', ':', '{', '&', '|', '^', '<', '>'
+};
 
 /**
  * All possible results of having performed some sort of parsing.

--- a/test/corpus/expressions.txt
+++ b/test/corpus/expressions.txt
@@ -1028,6 +1028,21 @@ let two = 2
     + 2
     - 2
 
+let mask = 1
+    | 2
+
+let intersection = 3
+    & 1
+
+let difference = 3
+    ^ 1
+
+let doubled = 1
+    << 1
+
+let halved = 2
+    >> 1
+
 --------------------------------------------------------------------------------
 
 (source_file
@@ -1059,6 +1074,41 @@ let two = 2
       (additive_expression
         (integer_literal)
         (integer_literal))
+      (integer_literal)))
+  (property_declaration
+    (value_binding_pattern)
+    (pattern
+      (simple_identifier))
+    (bitwise_operation
+      (integer_literal)
+      (integer_literal)))
+  (property_declaration
+    (value_binding_pattern)
+    (pattern
+      (simple_identifier))
+    (bitwise_operation
+      (integer_literal)
+      (integer_literal)))
+  (property_declaration
+    (value_binding_pattern)
+    (pattern
+      (simple_identifier))
+    (bitwise_operation
+      (integer_literal)
+      (integer_literal)))
+  (property_declaration
+    (value_binding_pattern)
+    (pattern
+      (simple_identifier))
+    (bitwise_operation
+      (integer_literal)
+      (integer_literal)))
+  (property_declaration
+    (value_binding_pattern)
+    (pattern
+      (simple_identifier))
+    (bitwise_operation
+      (integer_literal)
       (integer_literal))))
 
 ================================================================================


### PR DESCRIPTION
### Summary

- Preserve continued expressions when a new line starts with a bitwise operator.
- Cover &, |, ^, <<, and >> without duplicating newline-suppression ownership.
- Add a corpus case for each bitwise operator.

### Testing

- tree-sitter test